### PR TITLE
US6247 porting changes from Icehouse to Mitaka

### DIFF
--- a/networking_cisco/plugins/cisco/cpnr/.testr.conf
+++ b/networking_cisco/plugins/cisco/cpnr/.testr.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+test_command=python -m subunit.run discover ./tests/unit $LISTOPT $IDOPTION
+test_id_option=--load-list $IDFILE
+test_list_option=--list

--- a/networking_cisco/plugins/cisco/cpnr/PKG-INFO
+++ b/networking_cisco/plugins/cisco/cpnr/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: Cisco PNR DHCP/DNS Driver and Relay Processes
-Version: 1.0.0.dev0.g
+#Version: 1.0.0.dev0.g
 Summary: Cisco PNR DHCP/DNS Driver and Relay Processes
 Home-page: http://www.cisco.com/
 Author: Vikram Hosakote

--- a/networking_cisco/plugins/cisco/cpnr/PKG-INFO
+++ b/networking_cisco/plugins/cisco/cpnr/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: Cisco PNR DHCP/DNS Driver and Relay Processes
-#Version: 1.0.0.dev0.g
+Version: 1.0.0.dev0.g
 Summary: Cisco PNR DHCP/DNS Driver and Relay Processes
 Home-page: http://www.cisco.com/
 Author: Vikram Hosakote

--- a/networking_cisco/plugins/cisco/cpnr/cpnr_client.py
+++ b/networking_cisco/plugins/cisco/cpnr/cpnr_client.py
@@ -19,9 +19,8 @@
 
 import requests
 from requests import exceptions as r_exc
-
-from neutron.openstack.common import jsonutils
-from neutron.openstack.common import log as logging
+from oslo_serialization import jsonutils
+from oslo_log import log as logging
 from neutron.common import exceptions
 
 

--- a/networking_cisco/plugins/cisco/cpnr/dhcp_driver.py
+++ b/networking_cisco/plugins/cisco/cpnr/dhcp_driver.py
@@ -21,12 +21,15 @@ import os
 import shutil
 import time
 
-from oslo.config import cfg
+from oslo_config import cfg
+from oslo_utils import encodeutils
+from oslo_utils import importutils
+from oslo_utils import timeutils
+from oslo_log import log as logging
 
 from neutron.agent.linux import dhcp
 from neutron.agent.linux import ip_lib
 from neutron.agent.linux import utils
-from neutron.openstack.common import log as logging
 from neutron.plugins.cisco.cpnr import model
 from neutron.plugins.cisco.cpnr import netns
 
@@ -143,7 +146,7 @@ class RemoteServerDriver(dhcp.DhcpBase):
         return dhcp.Dnsmasq.should_enable_metadata(conf, network)
 
     @classmethod
-    def existing_dhcp_networks(cls, conf, root_helper):
+    def existing_dhcp_networks(cls, conf):
         """Return a list of existing networks ids that we have configs for."""
         return _devices.keys()
 
@@ -247,10 +250,10 @@ class SimpleCpnrDriver(RemoteServerDriver):
         return ver
 
     @classmethod
-    def existing_dhcp_networks(cls, conf, root_helper):
+    def existing_dhcp_networks(cls, conf):
         """Return a list of existing networks ids that we have configs for."""
         sup = super(SimpleCpnrDriver, cls)
-        superkeys = sup.existing_dhcp_networks(conf, root_helper)
+        superkeys = sup.existing_dhcp_networks(conf)
         return set(_networks.keys()) & set(superkeys)
 
     @classmethod

--- a/networking_cisco/plugins/cisco/cpnr/dhcp_driver.py
+++ b/networking_cisco/plugins/cisco/cpnr/dhcp_driver.py
@@ -26,7 +26,6 @@ from oslo_utils import encodeutils
 from oslo_utils import importutils
 from oslo_utils import timeutils
 from oslo_log import log as logging
-
 from neutron.agent.linux import dhcp
 from neutron.agent.linux import ip_lib
 from neutron.agent.linux import utils

--- a/networking_cisco/plugins/cisco/cpnr/dhcp_relay.py
+++ b/networking_cisco/plugins/cisco/cpnr/dhcp_relay.py
@@ -23,10 +23,10 @@ import struct
 import binascii
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 
 from neutron.common import config
-from neutron.openstack.common import log as logging
+from oslo_log import log as logging
 from neutron.plugins.cisco.cpnr import netns
 from neutron.plugins.cisco.cpnr import debug_stats
 
@@ -342,7 +342,7 @@ def main():
     eventlet.monkey_patch()
     cfg.CONF.register_opts(OPTS, 'cisco_pnr')
     cfg.CONF(project='neutron')
-    config.setup_logging(cfg.CONF)
+    config.setup_logging()
     if os.getuid() != 0:
         LOG.error(_('Must run dhcp relay as root'))
         return

--- a/networking_cisco/plugins/cisco/cpnr/dhcpopts.py
+++ b/networking_cisco/plugins/cisco/cpnr/dhcpopts.py
@@ -14,7 +14,7 @@
 
 import binascii
 
-from neutron.openstack.common import log as logging
+from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 

--- a/networking_cisco/plugins/cisco/cpnr/dns_relay.py
+++ b/networking_cisco/plugins/cisco/cpnr/dns_relay.py
@@ -24,10 +24,10 @@ import time
 import uuid
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
+from oslo_log import log as logging
 
 from neutron.common import config
-from neutron.openstack.common import log as logging
 from neutron.plugins.cisco.cpnr import netns
 from neutron.plugins.cisco.cpnr import debug_stats
 

--- a/networking_cisco/plugins/cisco/cpnr/model.py
+++ b/networking_cisco/plugins/cisco/cpnr/model.py
@@ -342,8 +342,13 @@ class Policy:
 
     @classmethod
     def from_neutron_port(cls, network, port):
-        if port.extra_dhcp_opts:
-            data = {'optionList': {'OptionItem': port.extra_dhcp_opts}}
+        opt_list = []
+        if hasattr(port, 'extra_dhcp_opts'):
+            for opt in port.extra_dhcp_opts:
+                opt_list.append(opt)
+
+        if opt_list:
+            data = {'optionList': {'OptionItem': opt_list}}
         else:
             data = {'optionList': {'list': []}}
         return cls(data)

--- a/networking_cisco/plugins/cisco/cpnr/model.py
+++ b/networking_cisco/plugins/cisco/cpnr/model.py
@@ -187,22 +187,22 @@ class Scope:
         ipv4_subnets = [sub for sub in network.subnets
                         if sub.enable_dhcp and sub.ip_version == 4]
         primary_subnet = ipv4_subnets[0].cidr
-	if (subnet.cidr == primary_subnet):
+    if (subnet.cidr == primary_subnet):
             data = {'name': subnet.id,
-                'vpnId': vpnid,
-                'subnet': subnet.cidr,
-                'rangeList': range_list,
-                'restrictToReservations': 'enabled',
-                'embeddedPolicy': policy.data}
-	else:
+                    'vpnId': vpnid,
+                    'subnet': subnet.cidr,
+                    'rangeList': range_list,
+                    'restrictToReservations': 'enabled',
+                    'embeddedPolicy': policy.data}
+    else:
             data = {'name': subnet.id,
-                'vpnId': vpnid,
-                'subnet': subnet.cidr,
-                'rangeList': range_list,
-                'restrictToReservations': 'enabled',
-                'embeddedPolicy': policy.data,
-                'primarySubnet': primary_subnet}
-        return cls(data)
+                    'vpnId': vpnid,
+                    'subnet': subnet.cidr,
+                    'rangeList': range_list,
+                    'restrictToReservations': 'enabled',
+                    'embeddedPolicy': policy.data,
+                    'primarySubnet': primary_subnet}
+    return cls(data)
 
     @classmethod
     def from_pnr(cls, scope):

--- a/networking_cisco/plugins/cisco/cpnr/model.py
+++ b/networking_cisco/plugins/cisco/cpnr/model.py
@@ -187,14 +187,14 @@ class Scope:
         ipv4_subnets = [sub for sub in network.subnets
                         if sub.enable_dhcp and sub.ip_version == 4]
         primary_subnet = ipv4_subnets[0].cidr
-    if (subnet.cidr == primary_subnet):
+        if (subnet.cidr == primary_subnet):
             data = {'name': subnet.id,
                     'vpnId': vpnid,
                     'subnet': subnet.cidr,
                     'rangeList': range_list,
                     'restrictToReservations': 'enabled',
                     'embeddedPolicy': policy.data}
-    else:
+        else:
             data = {'name': subnet.id,
                     'vpnId': vpnid,
                     'subnet': subnet.cidr,
@@ -202,7 +202,7 @@ class Scope:
                     'restrictToReservations': 'enabled',
                     'embeddedPolicy': policy.data,
                     'primarySubnet': primary_subnet}
-    return cls(data)
+        return cls(data)
 
     @classmethod
     def from_pnr(cls, scope):

--- a/networking_cisco/plugins/cisco/cpnr/model.py
+++ b/networking_cisco/plugins/cisco/cpnr/model.py
@@ -18,10 +18,10 @@ import time
 from itertools import groupby
 from operator import itemgetter
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from neutron.common import constants
-from neutron.openstack.common import log as logging
+from oslo_log import log as logging
 from neutron.agent.linux import dhcp
 from neutron.plugins.cisco.cpnr import cpnr_client
 from neutron.plugins.cisco.cpnr import dhcpopts
@@ -187,7 +187,15 @@ class Scope:
         ipv4_subnets = [sub for sub in network.subnets
                         if sub.enable_dhcp and sub.ip_version == 4]
         primary_subnet = ipv4_subnets[0].cidr
-        data = {'name': subnet.id,
+	if (subnet.cidr == primary_subnet):
+            data = {'name': subnet.id,
+                'vpnId': vpnid,
+                'subnet': subnet.cidr,
+                'rangeList': range_list,
+                'restrictToReservations': 'enabled',
+                'embeddedPolicy': policy.data}
+	else:
+            data = {'name': subnet.id,
                 'vpnId': vpnid,
                 'subnet': subnet.cidr,
                 'rangeList': range_list,
@@ -325,27 +333,17 @@ class Policy:
                          'domain-name': cfg.CONF.dhcp_domain}
         for option in extra_options.items():
             options.append(option)
-        opt_list = []
-        for name, val in options:
-            opt = dhcpopts.format_for_pnr(name, val)
-            if opt:
-                opt_list.append(opt)
-        if opt_list:
-            data = {'optionList': {'OptionItem': opt_list}}
+
+        if options:
+            data = {'optionList': {'OptionItem': options}}
         else:
             data = {'optionList': {'list': []}}
         return cls(data)
 
     @classmethod
     def from_neutron_port(cls, network, port):
-        opt_list = []
-        if hasattr(port, 'extra_dhcp_opts'):
-            for opt in port.extra_dhcp_opts:
-                opt = dhcpopts.format_for_pnr(opt.opt_name, opt.opt_value)
-                if opt:
-                    opt_list.append(opt)
-        if opt_list:
-            data = {'optionList': {'OptionItem': opt_list}}
+        if port.extra_dhcp_opts:
+            data = {'optionList': {'OptionItem': port.extra_dhcp_opts}}
         else:
             data = {'optionList': {'list': []}}
         return cls(data)
@@ -677,7 +675,7 @@ def get_version():
     try:
         pnr = _get_client()
         verstr = pnr.get_version()
-        version = float(verstr.split()[2])
+        version = verstr.split()[2]
     except cpnr_client.CpnrException:
         LOG.warn("Failed to obtain CPNR version number")
     except StandardError:

--- a/networking_cisco/plugins/cisco/cpnr/requirements.txt
+++ b/networking_cisco/plugins/cisco/cpnr/requirements.txt
@@ -1,10 +1,11 @@
-pbr>=0.6,!=0.7,<1.0
+pbr>=1.6 # Apache-2.0
 eventlet
 python-neutronclient
-oslo.concurrency
-oslo.config<2.0.0
-oslo.utils<2.0.0
-oslo.db
-oslo.log
-oslo.messaging
--e git://git.openstack.org/openstack/neutron.git@icehouse-eol#egg=neutron
+oslo.concurrency>=2.3.0 # Apache-2.0
+oslo.config>=3.2.0 # Apache-2.0
+oslo.context>=0.2.0 # Apache-2.0
+oslo.db>=4.1.0 # Apache-2.0
+oslo.log>=1.14.0 # Apache-2.0
+oslo.messaging>=4.0.0 # Apache-2.0
+oslo.utils>=3.4.0 # Apache-2.0
+-e git+https://git.openstack.org/openstack/neutron.git@stable/liberty#egg=neutron

--- a/networking_cisco/plugins/cisco/cpnr/setup.cfg
+++ b/networking_cisco/plugins/cisco/cpnr/setup.cfg
@@ -2,6 +2,7 @@
 name = Cisco PNR DHCP/DNS Driver and Relay Processes
 summary = Cisco PNR DHCP/DNS Driver and Relay Processes
 author = Vikram Hosakote
+version = 1.0.0
 author-email = vhosakot@cisco.com
 home-page = http://www.cisco.com/
 classifier =

--- a/networking_cisco/plugins/cisco/cpnr/setup.cfg
+++ b/networking_cisco/plugins/cisco/cpnr/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = Cisco PNR DHCP/DNS Driver and Relay Processes
-version = 1.0.0
 summary = Cisco PNR DHCP/DNS Driver and Relay Processes
 author = Vikram Hosakote
 author-email = vhosakot@cisco.com

--- a/networking_cisco/plugins/cisco/cpnr/tox.ini
+++ b/networking_cisco/plugins/cisco/cpnr/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py27,pep8
+envlist = pep8
+minversion = 2.3.1
 skipsdist = True
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
-         PYTHONHASHSEED=0
+passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
@@ -17,6 +18,7 @@ commands =
   sh tools/pretty_tox.sh '{posargs}'
 
 [testenv:pep8]
+basepython = python2.7
 commands = pep8 --exclude=*egg,.eggs/*,.tox/*
 
 [tox:jenkins]

--- a/networking_cisco/plugins/cisco/cpnr/tox.ini
+++ b/networking_cisco/plugins/cisco/cpnr/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8
+envlist = py27
 minversion = 2.3.1
 skipsdist = True
 

--- a/networking_cisco/tests/unit/cisco/cpnr/test_model.py
+++ b/networking_cisco/tests/unit/cisco/cpnr/test_model.py
@@ -14,8 +14,7 @@
 
 import mock
 
-from oslo.config import cfg
-
+from oslo_config import cfg
 from neutron.agent import dhcp_agent
 from neutron.plugins.cisco.cpnr import cpnr_client
 from neutron.plugins.cisco.cpnr import dhcp_driver
@@ -24,7 +23,7 @@ from neutron.plugins.cisco.cpnr import dhcpopts
 from neutron.plugins.cisco.cpnr.tests.unit import fake_networks
 from neutron.tests import base
 
-dhcp_agent.register_options()
+dhcp_agent.register_options(cfg.CONF)
 
 
 class TestModel(base.BaseTestCase):
@@ -91,8 +90,7 @@ class TestModel(base.BaseTestCase):
                     'subnet': '172.9.9.0/24',
                     'rangeList': range_list,
                     'restrictToReservations': 'enabled',
-                    'embeddedPolicy': policy.data,
-                    'primarySubnet': '172.9.9.0/24'}
+                    'embeddedPolicy': policy.data}
         self.client.update_scope.assert_called_once_with(
             expected['name'], expected)
 
@@ -141,8 +139,7 @@ class TestModel(base.BaseTestCase):
                     'subnet': '172.9.9.0/24',
                     'rangeList': range_list,
                     'restrictToReservations': 'enabled',
-                    'embeddedPolicy': policy.data,
-                    'primarySubnet': '172.9.9.0/24'}
+                    'embeddedPolicy': policy.data}
         self.client.update_scope.assert_called_once_with(
             expected['name'], expected)
 
@@ -193,8 +190,7 @@ class TestModel(base.BaseTestCase):
                     'subnet': '172.9.9.0/24',
                     'rangeList': range_list,
                     'restrictToReservations': 'enabled',
-                    'embeddedPolicy': policy.data,
-                    'primarySubnet': '172.9.9.0/24'}
+                    'embeddedPolicy': policy.data}
         self.client.update_scope.assert_called_once_with(
             expected['name'], expected)
 
@@ -265,7 +261,7 @@ class TestModel(base.BaseTestCase):
 
         self.client.get_version.return_value = "CPNR Version 8.3"
         ver = model.get_version()
-        self.assertEquals(ver, 8.3)
+        self.assertEquals(ver, '8.3')
 
     def test_recover_networks(self):
         self.client.reset_mock()
@@ -338,7 +334,7 @@ class TestModel(base.BaseTestCase):
         opt_list_pnr_format = [dhcpopts.format_for_pnr(opts_list[i].opt_name,
                                                        opts_list[i].opt_value)
                                for i in range(len(opts_list))]
-        expected = {'OptionItem': opt_list_pnr_format}
+        expected = {'OptionItem': opts_list}
         self.assertEquals(policy.data['optionList'], expected)
 
     def test_policy_from_subnet(self):
@@ -354,9 +350,7 @@ class TestModel(base.BaseTestCase):
                             ('dhcp-lease-time',
                              str(cfg.CONF.dhcp_lease_duration)),
                             ('domain-name', cfg.CONF.dhcp_domain)]
-        policy_list_pnr_format = [dhcpopts.format_for_pnr(name, val)
-                                  for name, val in fake_policy_opts]
-        expected = {'OptionItem': policy_list_pnr_format}
+        expected = {'OptionItem': fake_policy_opts}
         self.assertEquals(policy.data['optionList'], expected)
 
     def test_scope_from_subnet(self):
@@ -373,8 +367,7 @@ class TestModel(base.BaseTestCase):
                     'subnet': '172.9.9.0/24',
                     'rangeList': range_list,
                     'restrictToReservations': 'enabled',
-                    'embeddedPolicy': policy.data,
-                    'primarySubnet': '172.9.9.0/24'}
+                    'embeddedPolicy': policy.data}
         scope = model.Scope.from_neutron(fake_networks.fake_net3,
                                          fake_networks.fake_subnet1)
         self.assertEquals(scope.data, expected)


### PR DESCRIPTION
Following is commit trail of porting plugin changes from ICEHOUSE to LIBERTY and then LIBERTY to MITAKA.

Change Summary:
1. Used oslo_config for import instead of oslo.config
2. Corrected some function prototype.
3. Primary subnet and subnet overlapping issue
4. Rest API changes from 8.3 to 8.3.3 changes related to dhcp option list.
# 
# TOX report:
# Totals

Ran: 32 tests in 126.0000 sec.
- Passed: 32
- Skipped: 0
- Expected Fail: 0
- Unexpected Success: 0
- Failed: 0
  Sum of execute time for each test: 122.5970 sec.
# 
# Worker Balance
- Worker 0 (1 tests) => 0:02:00.248632
- Worker 1 (1 tests) => 0:00:00.232939
- Worker 2 (1 tests) => 0:00:00.308400
- Worker 3 (1 tests) => 0:00:00.214479
- Worker 4 (1 tests) => 0:00:00.225837
- Worker 5 (1 tests) => 0:00:00.236766
- Worker 6 (1 tests) => 0:00:00.209508
- Worker 7 (1 tests) => 0:00:00.202825
- Worker 8 (1 tests) => 0:00:00.223164
- Worker 9 (1 tests) => 0:00:00.241822
- Worker 10 (1 tests) => 0:00:00.222065
- Worker 11 (4 tests) => 0:00:00.002370
- Worker 12 (4 tests) => 0:00:00.014910
- Worker 13 (4 tests) => 0:00:00.006351
- Worker 14 (5 tests) => 0:00:00.008603
- Worker 15 (4 tests) => 0:00:00.006626
  pep8 develop-inst-nodeps: /opt/stack/neutron/neutron/plugins/cisco/cpnr
  pep8 installed: aioeventlet==0.4,alembic==0.8.4,amqp==1.4.9,anyjson==0.3.3,appdirs==1.4.0,Babel==2.2.0,beautifulsoup4==4.4.1,cachetools==1.1.5,-e git+https://git.openstack.org/openstack/neutron.git@6576b7061ea4c4068246bbd01f605a12e689c2c6#egg=Cisco_PNR_DHCP_DNS_Driver_and_Relay_Processes&subdirectory=neutron/plugins/cisco/cpnr,cliff==1.15.0,cmd2==0.6.8,contextlib2==0.5.1,debtcollector==1.2.0,decorator==4.0.6,ecdsa==0.13,enum34==1.1.2,eventlet==0.18.1,extras==0.0.3,fasteners==0.14.1,fixtures==1.4.0,funcsigs==0.4,functools32==3.2.3.post2,futures==3.0.4,futurist==0.9.0,greenlet==0.4.9,httplib2==0.9.2,iso8601==0.1.11,Jinja2==2.8,jsonschema==2.5.1,keystoneauth1==2.2.0,keystonemiddleware==4.2.0,kombu==3.0.33,linecache2==1.0.0,logutils==0.3.3,Mako==1.0.3,MarkupSafe==0.23,mock==1.3.0,monotonic==0.6,msgpack-python==0.4.7,netaddr==0.7.18,netifaces==0.10.4,-e git+https://git.openstack.org/openstack/neutron.git@99febcca47a5e760268bd03391f49d5c2a5e8fe9#egg=neutron,ordereddict==1.1,os-client-config==1.14.0,os-testr==0.6.0,oslo.concurrency==3.3.0,oslo.config==3.4.0,oslo.context==1.0.1,oslo.db==4.3.1,oslo.i18n==3.2.0,oslo.log==2.3.0,oslo.messaging==4.0.0,oslo.middleware==3.5.0,oslo.policy==1.3.0,oslo.rootwrap==3.1.0,oslo.serialization==2.2.0,oslo.service==1.3.0,oslo.utils==3.4.0,oslo.versionedobjects==1.4.0,paramiko==1.16.0,Paste==2.0.2,PasteDeploy==1.5.2,pbr==1.8.1,pecan==1.0.4,pep8==1.7.0,prettytable==0.7.2,pycadf==2.0.1,pycrypto==2.6.1,pyinotify==0.9.6,pyparsing==2.0.7,pyrsistent==0.11.10,python-dateutil==2.4.2,python-editor==0.5,python-keystoneclient==2.1.1,python-mimeparse==0.1.4,python-neutronclient==4.0.0,python-novaclient==3.2.0,python-subunit==1.2.0,pytz==2015.7,PyYAML==3.11,repoze.lru==0.6,requests==2.9.1,requestsexceptions==1.1.2,retrying==1.3.3,Routes==2.2,ryu==3.29.1,simplejson==3.8.1,singledispatch==3.4.0.3,six==1.10.0,SQLAlchemy==1.0.11,sqlalchemy-migrate==0.10.0,sqlparse==0.1.18,stevedore==1.10.0,tempest-lib==0.13.0,Tempita==0.5.2,testrepository==0.0.20,testscenarios==0.5.0,testtools==1.9.0,traceback2==1.4.0,trollius==2.0,unicodecsv==0.14.1,unittest2==1.1.0,waitress==0.8.10,WebOb==1.5.1,WebTest==2.0.20,wheel==0.26.0,wrapt==1.10.6
  pep8 runtests: PYTHONHASHSEED='3045308282'
  pep8 runtests: commands[0] | pep8 --exclude=_egg,.eggs/_,.tox/*
  ___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  pep8: commands succeeded
  congratulations :)
  =====================================

Commit Report:

commit 569d559f248192693bcba7735365ac420209d56e
Author: deepakkukrety dkukrety@cisco.com
Date:   Thu Jan 28 09:30:36 2016 +0530

```
US6247 porting changes from Liberty to Mitaka
```

commit df30f794c33600bcf081ae53e9e423bae6fc9fe1
Author: deepakkukrety dkukrety@cisco.com
Date:   Thu Jan 28 09:29:36 2016 +0530

```
US6247 porting changes from Liberty to Mitaka
```

commit 7cefefbcc85afcca987e9cbdbcc264ed9f07d6c3
Author: deepakkukrety dkukrety@cisco.com
Date:   Thu Jan 28 07:42:13 2016 +0530

```
US6247 porting changes from Liberty to Mitaka
```

commit 7c7eaf88c65b178955ea6dcea745de43c0a17754
Author: deepakkukrety dkukrety@cisco.com
Date:   Thu Jan 28 06:46:29 2016 +0530

```
US6247 porting changes from Liberty to Mitaka
```

commit 11f8f6cb3fc7a2f88db22efdb30efa0a5262f184
Author: deepakkukrety dkukrety@cisco.com
Date:   Wed Jan 27 07:47:18 2016 +0530

```
US6247 porting changes from Liberty to Mitaka
```

commit 2fa6f9c892874d5e2abaf06ffaa15f51fdd31877
Author: deepakkukrety dkukrety@cisco.com
Date:   Mon Jan 25 12:53:39 2016 +0530

```
Modified the import for logging
```
