### PR TITLE
US6548 - syntax error issue fixed for device_manager.setup() function

### DIFF
--- a/networking_cisco/plugins/cisco/cpnr/dhcp_driver.py
+++ b/networking_cisco/plugins/cisco/cpnr/dhcp_driver.py
@@ -186,8 +186,7 @@ class RemoteServerDriver(dhcp.DhcpBase):
                 return
             LOG.debug(_("Setting up device for network: %s"),
                       self.network.id)
-            ifname = self.device_manager.setup(self.network,
-                                               reuse_existing=True)
+            ifname = self.device_manager.setup(self.network)
             _devices[self.network.id] = ifname
             self._write_intf_file()
         elif disabled:


### PR DESCRIPTION
commit fec8cd37ee6926000897acbb1253b655ba81dc0c
Author: Sivamuru sivamuru@cisco.com
Date:   Thu Feb 4 06:52:48 2016 +0530

```
US6548 - syntax error issue fixed for device_manager.setup() function
```
