### PR TITLE
Fix subnet selection for global routers

### DIFF
--- a/networking_cisco/plugins/cisco/l3/drivers/asr1k/aci_asr1k_routertype_driver.py
+++ b/networking_cisco/plugins/cisco/l3/drivers/asr1k/aci_asr1k_routertype_driver.py
@@ -12,11 +12,17 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from networking_cisco.plugins.cisco.common import cisco_constants
+from networking_cisco.plugins.cisco.db.l3 import ha_db
 from networking_cisco.plugins.cisco.extensions import routerhostingdevice
+from networking_cisco.plugins.cisco.extensions import routerrole
+from networking_cisco.plugins.cisco.extensions import routertype
+from networking_cisco.plugins.cisco.extensions import routertypeawarescheduler
 from networking_cisco.plugins.cisco.l3.drivers.asr1k import (
     asr1k_routertype_driver as asr1k)
 from neutron.common import constants as l3_constants
 from neutron import context as nctx
+from neutron.extensions import l3
 from neutron.i18n import _LE, _LI
 from neutron import manager
 
@@ -24,6 +30,10 @@ from oslo_log import log as logging
 from oslo_utils import importutils
 
 LOG = logging.getLogger(__name__)
+
+HOSTING_DEVICE_ATTR = routerhostingdevice.HOSTING_DEVICE_ATTR
+ROUTER_ROLE_GLOBAL = cisco_constants.ROUTER_ROLE_GLOBAL
+ROUTER_ROLE_LOGICAL_GLOBAL = cisco_constants.ROUTER_ROLE_LOGICAL_GLOBAL
 
 
 APIC_ML2_L3DRIVER_KLASS = (
@@ -192,3 +202,104 @@ class AciASR1kL3RouterDriver(asr1k.ASR1kL3RouterDriver):
     def delete_floatingip_postcommit(self, context, fip_context):
         self.apic_driver.delete_floatingip_postcommit(
             context, fip_context.current)
+
+    def _conditionally_add_global_router(self, context, router):
+        """Create global router, if needed.
+
+        This override of the parent class is needed in order
+        to ensure that the proper subnet is used for the external
+        gateway port. In the GBP workflow, there can be multiple
+        subnets on the external network. In order to ensure that
+        the global router's gateway port is on the same subnet
+        as the user router, we pass in the subnet ID for the GW.
+        """
+        # We could filter on hosting device id but we don't so we get all
+        # global routers for this router type. We can then use that count to
+        # determine which ha priority a new global router should get.
+        filters = {
+            routerrole.ROUTER_ROLE_ATTR: [ROUTER_ROLE_GLOBAL],
+            routertype.TYPE_ATTR: [router[routertype.TYPE_ATTR]]}
+        global_routers = {
+            r[HOSTING_DEVICE_ATTR]: r for r in self._l3_plugin.get_routers(
+                context, filters=filters, fields=[HOSTING_DEVICE_ATTR])}
+        hosting_device_id = router[HOSTING_DEVICE_ATTR]
+        if hosting_device_id not in global_routers:
+            # must create global router on hosting device
+            # all global routers are connected to the external network
+            ext_nw = router[l3.EXTERNAL_GW_INFO]['network_id']
+            fixed_ips = router['external_gateway_info']['external_fixed_ips']
+            ext_ips = [{'subnet_id': fixed_ips[0]['subnet_id']}]
+            r_spec = {'router': {
+                # global routers are not tied to any tenant
+                'tenant_id': '',
+                'name': self._global_router_name(hosting_device_id),
+                'admin_state_up': True,
+                l3.EXTERNAL_GW_INFO: {'network_id': ext_nw,
+                                      'external_fixed_ips': ext_ips}}}
+            global_router, r_hd_b_db = self._l3_plugin.do_create_router(
+                context, r_spec, router[routertype.TYPE_ATTR], False, True,
+                hosting_device_id, ROUTER_ROLE_GLOBAL)
+            log_global_router = (
+                self._conditionally_add_logical_global_router(context,
+                                                              router))
+            # make the global router a redundancy router for the logical
+            # global router (which we treat as a hidden "user visible
+            # router" (how's that for a contradiction! :-) )
+            with context.session.begin(subtransactions=True):
+                ha_priority = (
+                    ha_db.DEFAULT_MASTER_PRIORITY -
+                    len(global_routers) * ha_db.PRIORITY_INCREASE_STEP)
+                r_b_b = ha_db.RouterRedundancyBinding(
+                    redundancy_router_id=global_router['id'],
+                    priority=ha_priority,
+                    user_router_id=log_global_router['id'])
+                context.session.add(r_b_b)
+            self._l3_plugin.add_type_and_hosting_device_info(context,
+                                                             global_router)
+            for ni in self._l3_plugin.get_notifiers(context, [global_router]):
+                if ni['notifier']:
+                    ni['notifier'].routers_updated(context, ni['routers'])
+
+    def _conditionally_add_logical_global_router(self, context, router):
+        """Create logical global router, if needed.
+
+        This override of the parent class is needed in order
+        to ensure that the proper subnet is used for the external
+        gateway port. In the GBP workflow, there can be multiple
+        subnets on the external network. In order to ensure that
+        the logical global router's gateway port is on the same subnet
+        as the user router, we pass in the subnet ID for the GW.
+        """
+        # Since HA is also enabled on the global routers on each hosting device
+        # those global routers need HA settings and VIPs. We represent that
+        # using a Neutron router that is never instantiated/hosted. That
+        # Neutron router is referred to as the "logical global" router.
+        filters = {routerrole.ROUTER_ROLE_ATTR: [ROUTER_ROLE_LOGICAL_GLOBAL],
+                   routertype.TYPE_ATTR: [router[routertype.TYPE_ATTR]]}
+        logical_global_routers = self._l3_plugin.get_routers(
+            context, filters=filters)
+        if not logical_global_routers:
+            ext_nw = router[l3.EXTERNAL_GW_INFO]['network_id']
+            fixed_ips = router['external_gateway_info']['external_fixed_ips']
+            ext_ips = [{'subnet_id': fixed_ips[0]['subnet_id']}]
+            r_spec = {'router': {
+                # global routers are not tied to any tenant
+                'tenant_id': '',
+                'name': self._global_router_name('', logical=True),
+                'admin_state_up': True,
+                l3.EXTERNAL_GW_INFO: {'network_id': ext_nw,
+                                      'external_fixed_ips': ext_ips},
+                # set auto-schedule to false to keep this router un-hosted
+                routertypeawarescheduler.AUTO_SCHEDULE_ATTR: False}}
+            # notifications should never be sent for this logical router!
+            logical_global_router, r_hd_b_db = (
+                self._l3_plugin.do_create_router(
+                    context, r_spec, router[routertype.TYPE_ATTR], False,
+                    True, None, ROUTER_ROLE_LOGICAL_GLOBAL))
+            self._provision_ha(context, logical_global_router)
+        else:
+            logical_global_router = logical_global_routers[0]
+            with context.session.begin(subtransactions=True):
+                self._update_ha_redundancy_level(context,
+                                                 logical_global_router, 1)
+        return logical_global_router

--- a/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_aciasr1k_routertype_driver.py
@@ -96,6 +96,12 @@ class AciAsr1kRouterTypeDriverTestCase(
                                       cidr='1.103.2.0/24', tenant_id=tenant_id)
             s = self.deserialize(self.fmt, res)
             self._set_net_external(s['subnet']['network_id'])
+            # add a second subnet, just to verify that when we create
+            # the global router that it picks the correct subnet
+            res = self._create_subnet(self.fmt, n_external['network']['id'],
+                                      cidr='1.103.3.0/24', tenant_id=tenant_id)
+            s2 = self.deserialize(self.fmt, res)
+            self._set_net_external(s2['subnet']['network_id'])
             with self.router(tenant_id=tenant_id,
                              set_context=set_context) as router1,\
                     self.router(name='router2', tenant_id=tenant_id,


### PR DESCRIPTION
This fixes the selection of the proper subnet when creating
the global and logical global routers. When multiple subnets
exist on the external network, the code would select the subnet
with the lower UUID (i.e. the one appearing first in a list).
This patch fixes it so that the global and logical global
routers use the same subent as the user's router.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
