### PR TITLE
Add configuration of secondary IPs for NAT

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_snippets.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_snippets.py
@@ -100,3 +100,31 @@ REMOVE_STATIC_SRC_TRL_NO_VRF_MATCH = """
         </cli-config-data>
 </config>
 """
+
+# =======================================================
+# Add secondary IP
+# $(config)interface GigabitEthernet 2.500
+# $(config)ip address 192.168.0.1 255.255.255.0 secondary
+# =======================================================
+ADD_SECONDARY_IP = """
+<config>
+        <cli-config-data>
+            <cmd>interface %s</cmd>
+            <cmd>ip address %s %s secondary</cmd>
+        </cli-config-data>
+</config>
+"""
+
+# =======================================================
+# Remove secondary IP
+# $(config)interface GigabitEthernet 2.500
+# $(config)no ip address 192.168.0.1 255.255.255.0 secondary
+# =======================================================
+REMOVE_SECONDARY_IP = """
+<config>
+        <cli-config-data>
+            <cmd>interface %s</cmd>
+            <cmd>no ip address %s %s secondary</cmd>
+        </cli-config-data>
+</config>
+"""


### PR DESCRIPTION
This adds configuration of secondary IP addresses on the
external interface for each NAT subnet. It uses the last
address in the subnet for the secondary address.  This is
only used for GBP workflows (indicated in hosting_info
attribute).

Signed-off-by: Thomas Bachman tbachman@yahoo.com
