### PR TITLE
Missing DB migration utility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ setup-hooks =
 
 [entry_points]
 console_scripts =
+    networking-cisco-db-manage = networking_cisco.db.migration.cli:main
     neutron-cisco-cfg-agent = networking_cisco.plugins.cisco.cfg_agent.cfg_agent:main
 neutron.core_plugins =
     cisco = neutron.plugins.cisco.network_plugin:PluginV2


### PR DESCRIPTION
The DB migration tool wasn't provided as part of the
packaging.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
