### PR TITLE
Replace ciscoconfparser with HTParser

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_cfg_syncer.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_cfg_syncer.py
@@ -20,20 +20,17 @@ import xml.etree.ElementTree as ET
 
 from oslo_config import cfg
 from oslo_log import log as logging
-from oslo_utils import importutils
 
 from neutron.common import constants
 from neutron.i18n import _LI
 
-# from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
-#    cisco_csr1kv_snippets as snippets)
 from networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k import (
     asr1k_snippets as asr_snippets)
 from networking_cisco.plugins.cisco.common import cisco_constants
+from networking_cisco.plugins.cisco.common.htparser import HTParser
 from networking_cisco.plugins.cisco.extensions import ha
 from networking_cisco.plugins.cisco.extensions import routerrole
 
-ciscoconfparse = importutils.try_import('ciscoconfparse')
 
 LOG = logging.getLogger(__name__)
 
@@ -278,7 +275,7 @@ class ConfigSyncer(object):
                 LOG.info(intf_info)
 
         running_cfg = self.get_running_config(conn)
-        parsed_cfg = ciscoconfparse.CiscoConfParse(running_cfg)
+        parsed_cfg = HTParser(running_cfg)
 
         invalid_cfg = []
 

--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_cfg_validator.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_cfg_validator.py
@@ -14,7 +14,7 @@
 
 import netaddr
 
-from oslo_utils import importutils
+from networking_cisco.plugins.cisco.common.htparser import HTParser
 
 from neutron.common import constants
 
@@ -25,7 +25,6 @@ from networking_cisco.plugins.cisco.extensions import routerrole
 import re
 import xml.etree.ElementTree as ET
 
-ciscoconfparse = importutils.try_import('ciscoconfparse')
 
 ROUTER_ROLE_ATTR = routerrole.ROUTER_ROLE_ATTR
 
@@ -74,7 +73,7 @@ class ConfigValidator(object):
         segment_nat_dict = {}
         #conn = self.driver._get_connection() #TODO(init ncclient properly)
         running_cfg = self.get_running_config(self.conn)
-        parsed_cfg = ciscoconfparse.CiscoConfParse(running_cfg)
+        parsed_cfg = HTParser(running_cfg)
 
         self.populate_segment_nat_dict(segment_nat_dict, routers)
 

--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/csr1kv/csr1kv_routing_driver.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/csr1kv/csr1kv_routing_driver.py
@@ -29,9 +29,9 @@ from networking_cisco.plugins.cisco.cfg_agent.device_drivers import (
     devicedriver_api)
 from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
     cisco_csr1kv_snippets as snippets)
+from networking_cisco.plugins.cisco.common.htparser import HTParser
 from networking_cisco.plugins.cisco.extensions import ha
 
-ciscoconfparse = importutils.try_import('ciscoconfparse')
 manager = importutils.try_import('ncclient.manager')
 
 LOG = logging.getLogger(__name__)
@@ -347,7 +347,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
         :return: List of the interfaces
         """
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         intfs_raw = parse.find_lines("^interface GigabitEthernet")
         intfs = [raw_if.strip().split(' ')[1] for raw_if in intfs_raw]
         LOG.info(_LI("Interfaces:%s"), intfs)
@@ -360,7 +360,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
         :return: ip address of interface as a string
         """
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         children = parse.find_children("^interface %s" % interface_name)
         for line in children:
             if 'ip address' in line:
@@ -373,7 +373,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
     def _interface_exists(self, interface):
         """Check whether interface exists."""
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         intfs_raw = parse.find_lines("^interface " + interface)
         return len(intfs_raw) > 0
 
@@ -415,7 +415,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
         """
         vrfs = []
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         vrfs_raw = parse.find_lines("^vrf definition")
         for line in vrfs_raw:
             #  raw format ['ip vrf <vrf-name>',....]
@@ -464,7 +464,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
         exp_cfg_lines = ['ip access-list standard ' + str(acl_no),
                          ' permit ' + str(network) + ' ' + str(netmask)]
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         acls_raw = parse.find_children(exp_cfg_lines[0])
         if acls_raw:
             if exp_cfg_lines[1] in acls_raw:
@@ -481,7 +481,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
         :return : True or False
         """
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         cfg_raw = parse.find_lines("^" + cfg_str)
         LOG.debug("_cfg_exists(): Found lines %s", cfg_raw)
         return len(cfg_raw) > 0
@@ -541,7 +541,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
 
     def _get_interface_cfg(self, interface):
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         return parse.find_children('interface ' + interface)
 
     def _nat_rules_for_internet_access(self, acl_no, network,
@@ -639,7 +639,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
 
     def _get_floating_ip_cfg(self):
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         res = parse.find_lines('ip nat inside source static')
         return res
 
@@ -657,7 +657,7 @@ class CSR1kvRoutingDriver(devicedriver_api.RoutingDriverBase):
 
     def _get_static_route_cfg(self):
         ioscfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ioscfg)
+        parse = HTParser(ioscfg)
         return parse.find_lines('ip route')
 
     def _add_default_static_route(self, gw_ip, vrf):

--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/csr1kv/iosxe_routing_driver.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/csr1kv/iosxe_routing_driver.py
@@ -29,9 +29,9 @@ from networking_cisco.plugins.cisco.cfg_agent.device_drivers import (
     devicedriver_api)
 from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
     cisco_csr1kv_snippets as snippets)
+from networking_cisco.plugins.cisco.common.htparser import HTParser
 from networking_cisco.plugins.cisco.extensions import ha
 
-ciscoconfparse = importutils.try_import('ciscoconfparse')
 ncclient = importutils.try_import('ncclient')
 manager = importutils.try_import('ncclient.manager')
 
@@ -333,7 +333,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
         :return: List of the interfaces
         """
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         itfcs_raw = parse.find_lines("^interface GigabitEthernet")
         itfcs = [raw_if.strip().split(' ')[1] for raw_if in itfcs_raw]
         LOG.debug("Interfaces on hosting device: %s", itfcs)
@@ -346,7 +346,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
         :return: ip address of interface as a string
         """
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         children = parse.find_children("^interface %s" % interface_name)
         for line in children:
             if 'ip address' in line:
@@ -359,7 +359,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
     def _interface_exists(self, interface):
         """Check whether interface exists."""
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         itfcs_raw = parse.find_lines("^interface " + interface)
         return len(itfcs_raw) > 0
 
@@ -401,7 +401,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
         """
         vrfs = []
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         vrfs_raw = parse.find_lines("^vrf definition")
         for line in vrfs_raw:
             #  raw format ['ip vrf <vrf-name>',....]
@@ -450,7 +450,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
         exp_cfg_lines = ['ip access-list standard ' + str(acl_no),
                          ' permit ' + str(network) + ' ' + str(netmask)]
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         acls_raw = parse.find_children(exp_cfg_lines[0])
         if acls_raw:
             if exp_cfg_lines[1] in acls_raw:
@@ -467,7 +467,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
         :return : True or False
         """
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         cfg_raw = parse.find_lines("^" + cfg_str)
         LOG.debug("_cfg_exists(): Found lines %s", cfg_raw)
         return len(cfg_raw) > 0
@@ -515,7 +515,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
 
     def _get_interface_cfg(self, interface):
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         return parse.find_children('interface ' + interface)
 
     def _nat_rules_for_internet_access(self, acl_no, network,
@@ -592,7 +592,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
 
     def _get_floating_ip_cfg(self):
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         res = parse.find_lines('ip nat inside source static')
         return res
 
@@ -606,7 +606,7 @@ class IosXeRoutingDriver(devicedriver_api.RoutingDriverBase):
 
     def _get_static_route_cfg(self):
         ios_cfg = self._get_running_config()
-        parse = ciscoconfparse.CiscoConfParse(ios_cfg)
+        parse = HTParser(ios_cfg)
         return parse.find_lines('ip route')
 
     def caller_name(self, skip=2):

--- a/networking_cisco/plugins/cisco/common/htparser.py
+++ b/networking_cisco/plugins/cisco/common/htparser.py
@@ -1,0 +1,155 @@
+# Copyright 2016 Cisco Systems, Inc.  All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# A tiny and simple parser for the configs fetched from a cisco IOS device.
+#
+
+import re
+
+
+class LineItem(object):
+
+    def __init__(self, line):
+        self.line = line
+        self.text = line.strip()
+        self.parent = self
+        self.children = None
+
+    def add_children(self, child):
+        if self.children:
+            self.children.append(child)
+        else:
+            self.children = [child]
+
+    def str_list(self):
+        if self.children:
+            return [self.line] + [i.str_list() for i in self.children]
+        else:
+            return self.line
+
+    def re_search_children(self, linespec):
+        return HTParser(self.str_list()).find_objects(linespec)
+
+    def re_match(self, regex, group=1, default=""):
+        match = re.match(regex, self.line)
+        return match.group(group) if match else default
+
+    def __repr__(self):
+        return "<{} '{}'>".format(self.__class__.__name__, self.text)
+
+    def __eq__(self, other):
+        return self.str_list() == other.str_list()
+
+
+class HTParser(object):
+    """
+    A simple hierarchical text parser.
+
+    Indents in the text are used to derive parent child
+    hierarchy.
+    """
+
+    def __init__(self, cfg):
+        self._indent_list = []  # Stores items as (<indent_level>,<item>)
+        if isinstance(cfg, list):
+            self.cfg = cfg
+        elif isinstance(cfg, str):
+            self.cfg = [x for x in cfg.splitlines() if x]
+        else:
+            raise TypeError
+
+    def _build_indent_based_list(self):
+        self._indent_list = []
+        for line in self.cfg:
+            match = re.match(r'([ ]*)[^! ]', line)
+            if match:
+                item = (len(match.group(1)), line)
+                self._indent_list.append(item)
+
+    def _find_starts(self, linespec):
+        """
+        Finds the start points.
+
+        Start points matching the linespec regex are returned as list in the
+        following format:
+        [(item, index), (item, index).....
+         """
+        linespec += ".*"
+        start_points = []
+        for item in self._indent_list:
+            match = re.search(linespec, item[1])
+            if match:
+                entry = (item, self._indent_list.index(item))
+                start_points.append(entry)
+        return start_points
+
+    def _find_next_indent_level(self, index):
+        current_indent_level = self._indent_list[index][0]
+        for item in self._indent_list[(index + 1):]:
+            if item[0] > current_indent_level:
+                return item[0]
+            else:
+                return None
+
+    def find_lines(self, linespec):
+        """Find lines that match the linespec regex."""
+        res = []
+        linespec += ".*"
+        for line in self.cfg:
+            match = re.search(linespec, line)
+            if match:
+                res.append(match.group(0))
+        return res
+
+    def find_objects(self, linespec):
+        """Find lines that match the linespec regex.
+
+        :param linespec: regular expression of line to match
+        :return: list of LineItem objects
+        """
+        # Note(asr1kteam): In this code we are only adding children one-level
+        # deep to a given parent (linespec), as that satisfies the IOS conf
+        # parsing.
+        # Note(asr1kteam): Not tested with tabs in the config. Currently used
+        # with IOS config where we haven't seen tabs, but may be needed for a
+        # more general case.
+        res = []
+        self._build_indent_based_list()
+        for item, index in self._find_starts(linespec):
+            parent = LineItem(item[1])
+            next_ident_level = self._find_next_indent_level(index)
+            if next_ident_level:
+                # We start iterating from the next element
+                for item in self._indent_list[(index + 1):]:
+                    if item[0] == next_ident_level:
+                        parent.add_children(LineItem(item[1]))
+                    elif item[0] > next_ident_level:  # We skip higher indent
+                        continue
+                    else:  # Indent level is same or lesser than item
+                        break
+            res.append(parent)
+        return res
+
+    def find_children(self, linespec):
+        """Find lines and immediate children that match the linespec regex.
+
+        :param linespec: regular expression of line to match
+        :return: list of lines. These correspond to the lines that were
+        matched and their immediate children
+        """
+        res = []
+        for parent in self.find_objects(linespec):
+            res.append(parent.line)
+            res.extend([child.line for child in parent.children])
+        return res

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
@@ -34,7 +34,6 @@ from networking_cisco.tests.unit.cisco.cfg_agent import (
 from neutron.common import constants as l3_constants
 
 sys.modules['ncclient'] = mock.MagicMock()
-sys.modules['ciscoconfparse'] = mock.MagicMock()
 
 _uuid = uuidutils.generate_uuid
 HA_INFO = 'ha_info'

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_cfg_syncer.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_cfg_syncer.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import ciscoconfparse
 from oslo_config import cfg
 from oslo_serialization import jsonutils
 
@@ -24,6 +23,7 @@ from networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k import (
 
 from networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k import (
     asr1k_routing_driver as driver)
+from networking_cisco.plugins.cisco.common.htparser import HTParser
 
 
 cfg.CONF.register_opts(driver.ASR1K_DRIVER_OPTS, "multi_region")
@@ -153,7 +153,7 @@ class ASR1kCfgSyncer(base.TestCase):
         asr_running_cfg = self._read_asr_running_cfg(
             file_name='asr_running_cfg_no_R2.json')
 
-        parsed_cfg = ciscoconfparse.CiscoConfParse(asr_running_cfg)
+        parsed_cfg = HTParser(asr_running_cfg)
 
         invalid_cfg += self.config_syncer.clean_interfaces(conn,
                                               intf_segment_dict,
@@ -180,7 +180,7 @@ class ASR1kCfgSyncer(base.TestCase):
         asr_running_cfg = self._read_asr_running_cfg(
             file_name='asr_running_cfg_no_R2.json')
 
-        parsed_cfg = ciscoconfparse.CiscoConfParse(asr_running_cfg)
+        parsed_cfg = HTParser(asr_running_cfg)
 
         invalid_cfg += self.config_syncer.clean_interfaces(conn,
                                               intf_segment_dict,
@@ -211,7 +211,7 @@ class ASR1kCfgSyncer(base.TestCase):
         # This will trigger gateway only testing
         # asr_running_cfg = \
         #    self._read_asr_running_cfg('asr_basic_running_cfg.json')
-        parsed_cfg = ciscoconfparse.CiscoConfParse(asr_running_cfg)
+        parsed_cfg = HTParser(asr_running_cfg)
 
         invalid_cfg += self.config_syncer.clean_interfaces(conn,
                                               intf_segment_dict,
@@ -245,7 +245,7 @@ class ASR1kCfgSyncer(base.TestCase):
         asr_running_cfg = \
             self._read_asr_running_cfg(
                                     'asr_running_cfg_with_invalid_intfs.json')
-        parsed_cfg = ciscoconfparse.CiscoConfParse(asr_running_cfg)
+        parsed_cfg = HTParser(asr_running_cfg)
         invalid_cfg += self.config_syncer.clean_interfaces(conn,
                                               intf_segment_dict,
                                               segment_nat_dict,
@@ -271,7 +271,7 @@ class ASR1kCfgSyncer(base.TestCase):
             self._read_asr_running_cfg(
                                     'asr_running_cfg.json')
 
-        parsed_cfg = ciscoconfparse.CiscoConfParse(asr_running_cfg)
+        parsed_cfg = HTParser(asr_running_cfg)
 
         invalid_cfg += self.config_syncer.clean_acls(conn,
                                                      intf_segment_dict,
@@ -299,7 +299,7 @@ class ASR1kCfgSyncer(base.TestCase):
             self._read_asr_running_cfg(
                                     'asr_running_cfg.json')
 
-        parsed_cfg = ciscoconfparse.CiscoConfParse(asr_running_cfg)
+        parsed_cfg = HTParser(asr_running_cfg)
         invalid_cfg += self.config_syncer.clean_nat_pool_overload(conn,
                                                      router_id_dict,
                                                      intf_segment_dict,

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_routing_driver.py
@@ -38,7 +38,6 @@ from networking_cisco.plugins.cisco.extensions import ha
 from networking_cisco.plugins.cisco.extensions import routerrole
 
 sys.modules['ncclient'] = mock.MagicMock()
-sys.modules['ciscoconfparse'] = mock.MagicMock()
 
 _uuid = uuidutils.generate_uuid
 FAKE_ID = _uuid()

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_csr1kv_hotplug_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_csr1kv_hotplug_routing_driver.py
@@ -25,7 +25,6 @@ from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
 from oslo_utils import uuidutils
 
 sys.modules['ncclient'] = mock.MagicMock()
-sys.modules['ciscoconfparse'] = mock.MagicMock()
 
 _uuid = uuidutils.generate_uuid
 FAKE_ID = _uuid()

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_csr1kv_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_csr1kv_routing_driver.py
@@ -24,7 +24,6 @@ from neutron.tests import base
 from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
     cisco_csr1kv_snippets as snippets)
 sys.modules['ncclient'] = mock.MagicMock()
-sys.modules['ciscoconfparse'] = mock.MagicMock()
 from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
     csr1kv_routing_driver as csr_driver)
 from networking_cisco.plugins.cisco.cfg_agent.service_helpers import (

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_device_status.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_device_status.py
@@ -18,7 +18,6 @@ import mock
 from oslo_utils import uuidutils
 
 sys.modules['ncclient'] = mock.MagicMock()
-sys.modules['ciscoconfparse'] = mock.MagicMock()
 from networking_cisco.plugins.cisco.cfg_agent import device_status
 from neutron.tests import base
 

--- a/networking_cisco/tests/unit/cisco/common/test_htparser.py
+++ b/networking_cisco/tests/unit/cisco/common/test_htparser.py
@@ -1,0 +1,288 @@
+# Copyright 2016 Cisco Systems, Inc.  All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k import (
+    asr1k_cfg_syncer)
+from networking_cisco.plugins.cisco.common.htparser import HTParser
+from neutron.tests import base
+
+
+CFG = """
+!
+interface TenGigabitEthernet0/0/0
+ ip address 1.1.2.1 255.255.255.0
+ no cdp enable
+!
+interface Serial1/0
+ no ip address
+!
+ip access-list standard neutron_acl_2033_5c409ae1
+ permit 10.10.0.0 0.0.255.255
+    dummy-input
+ dummy-input2
+!
+interface Port-channel11.2000
+ description OPENSTACK_NEUTRON_EXTERNAL_INTF
+ encapsulation dot1Q 2000
+ ip address 15.15.6.117 255.255.0.0
+ ip nat outside
+ standby delay minimum 30 reload 60
+ standby version 2
+ standby 1064 ip 15.15.6.116
+ standby 1064 timers 1 3
+ standby 1064 priority 97
+ standby 1064 name neutron-hsrp-1064-2000
+ !
+interface Port-channel11.2033
+ description OPENSTACK_NEUTRON_INTF
+ encapsulation dot1Q 2033
+ vrf forwarding nrouter-6c5541
+ ip address 10.10.0.12 255.255.0.0
+ ip nat inside
+
+interface Port-channel11.2055
+ ip address 20.20.20.1 255.255.255.0
+"""
+
+FIND_LINES = "find_lines"
+FIND_CHILDREN = "find_children"
+FIND_OBJECTS = "find_objects"
+RE_SEARCH_CHILDREN = "re_search_children"
+ACL_CHILD_REGEX = asr1k_cfg_syncer.ACL_CHILD_REGEX
+
+
+class TestHTParser(base.BaseTestCase):
+    def setUp(self):
+        super(TestHTParser, self).setUp()
+        self.cfg = [x for x in CFG.splitlines()]
+
+    def _execute(self, function_name, linespec):
+        return getattr(HTParser(self.cfg), function_name)(linespec)
+
+    def test_find_lines_singleline(self):
+        linespec = "^interface TenGigabitEthernet0/0/0"
+        expected = ["interface TenGigabitEthernet0/0/0"]
+        actual = self._execute(FIND_LINES, linespec)
+        self.assertEqual(expected, actual)
+
+    def test_find_lines_mutliline(self):
+        extra_cfg = [
+            'interface TenGigabitEthernet0/0/0',
+            '    no ip address',
+            '    channel-group 10 mode active',
+            '    !'
+        ]
+        self.cfg.extend(extra_cfg)
+        linespec = "^interface TenGigabitEthernet0/0/0"
+        exp = ["interface TenGigabitEthernet0/0/0",
+               "interface TenGigabitEthernet0/0/0"]
+        act = self._execute(FIND_LINES, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_lines_similiarlines(self):
+        extra_cfg = [
+            'interface TenGigabitEthernet0/0/1',
+            '    no ip address',
+            '    channel-group 10 mode active',
+            '    !'
+        ]
+        self.cfg.extend(extra_cfg)
+        linespec = "^interface TenGigabitEthernet0/0/0"
+        exp = ["interface TenGigabitEthernet0/0/0"]
+        act = self._execute(FIND_LINES, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_lines_multiple(self):
+        extra_cfg = [
+            'interface TenGigabitEthernet0/0/1',
+            '    no ip address',
+            '    channel-group 10 mode active',
+            '    !'
+        ]
+        self.cfg.extend(extra_cfg)
+        linespec = "^interface TenGigabitEthernet"
+        exp = ["interface TenGigabitEthernet0/0/0",
+               "interface TenGigabitEthernet0/0/1"]
+        act = self._execute(FIND_LINES, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_lines_vrf_def(self):
+        extra_cfg = [
+            'vrf definition nrouter-bf7c12',
+            ' !',
+            ' address-family ipv4',
+            ' exit-address-family',
+            ' !',
+            ' address-family ipv6',
+            ' exit-address-family',
+            ' !',
+        ]
+        self.cfg.extend(extra_cfg)
+        linespec = "^vrf definition"
+        exp = ["vrf definition nrouter-bf7c12"]
+        act = self._execute(FIND_LINES, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_children_interface(self):
+        linespec = "^interface TenGigabitEthernet0/0/0"
+        exp = ["interface TenGigabitEthernet0/0/0",
+               " ip address 1.1.2.1 255.255.255.0",
+               " no cdp enable"]
+        act = self._execute(FIND_CHILDREN, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_children_acl(self):
+        linespec = "ip access-list standard neutron_acl_2033_5c409ae1"
+        exp = ['ip access-list standard neutron_acl_2033_5c409ae1',
+               ' permit 10.10.0.0 0.0.255.255',
+               ' dummy-input2']
+        act = self._execute(FIND_CHILDREN, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_children_acl_multiline(self):
+        extra_cfg = [
+            'ip access-list standard neutron_acl_1234_5678',
+            '    permit 10.10.0.0 0.0.255.255'
+        ]
+        self.cfg.extend(extra_cfg)
+        linespec = "ip access-list standard neutron_acl_*"
+        exp = ['ip access-list standard neutron_acl_2033_5c409ae1',
+               ' permit 10.10.0.0 0.0.255.255',
+               ' dummy-input2',
+               'ip access-list standard neutron_acl_1234_5678',
+               '    permit 10.10.0.0 0.0.255.255']
+        act = self._execute(FIND_CHILDREN, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_children_acl_no_find(self):
+        linespec = "ip access-list standard neutron_acl_xyz"
+        exp = []
+        act = self._execute(FIND_CHILDREN, linespec)
+        self.assertEqual(exp, act)
+
+    def test_find_children_interface_spec(self):
+        linespec = "^interface Port-channel11.2055"
+        exp = ['interface Port-channel11.2055',
+               ' ip address 20.20.20.1 255.255.255.0']
+        act = self._execute(FIND_CHILDREN, linespec)
+        self.assertEqual(exp, act)
+
+    # Object based tests
+    def test_find_objects(self):
+        linespec = "^interface TenGigabitEthernet0/0/0"
+        exp = ['interface TenGigabitEthernet0/0/0',
+               ' ip address 1.1.2.1 255.255.255.0',
+               ' no cdp enable']
+        act = self._execute(FIND_OBJECTS, linespec)
+        self.assertEqual(1, len(act))
+        self.assertEqual(exp, act[0].str_list())
+
+    def test_find_objects_no_find(self):
+        linespec = "^interface TenGigabitEthernet0/0/1"
+        exp = []
+        act = self._execute(FIND_OBJECTS, linespec)
+        self.assertEqual(exp, act)
+
+    def test_re_search_children_interface(self):
+        linespec = "^interf"
+        child_linespec = "\s*no ip*"
+        exp = ['interface Serial1/0', ' no ip address']
+        parse = HTParser(self.cfg)
+        act = [obj for obj in parse.find_objects(linespec)
+               if obj.re_search_children(child_linespec)]
+        self.assertEqual(1, len(act))
+        self.assertEqual(exp, act[0].str_list())
+
+    def test_re_search_children_acl(self):
+        linespec = "^ip access"
+        child_linespec = ACL_CHILD_REGEX
+        exp = ['ip access-list standard neutron_acl_2033_5c409ae1',
+               ' permit 10.10.0.0 0.0.255.255',
+               ' dummy-input2']
+        parse = HTParser(self.cfg)
+        act = [obj for obj in parse.find_objects(linespec)
+               if obj.re_search_children(child_linespec)]
+        self.assertEqual(1, len(act))
+        self.assertEqual(exp, act[0].str_list())
+
+    def test_re_match_nat(self):
+        linespec = "^interf"
+        child_linespec = "\s*ip nat inside"
+        match_regex = "^interface (\S+)"
+        exp = 'Port-channel11.2033'
+        parse = HTParser(self.cfg)
+        act = [obj for obj in parse.find_objects(linespec)
+               if obj.re_search_children(child_linespec)]
+        self.assertEqual(1, len(act))
+        self.assertEqual(exp, act[0].re_match(match_regex))
+
+    def test_build_indent_based_list__singleline_noindent(self):
+        LINE = 'cfg_line'
+        cfg = LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        self.assertEqual([(0, LINE)], parser._indent_list)
+
+    def test_build_indent_based_list__multiline_noindent(self):
+        LINE = 'cfg_line'
+        cfg = LINE + '\n' + LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        res = [(0, LINE), (0, LINE)]
+        self.assertEqual(res, parser._indent_list)
+
+    def test_build_indent_based_list__singleline_indent(self):
+        LINE = '  cfg_line'
+        cfg = LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        self.assertEqual([(2, LINE)], parser._indent_list)
+
+    def test_build_indent_based_list__singleline_comment(self):
+        LINE = '!'
+        cfg = LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        self.assertEqual([], parser._indent_list)
+
+    def test_build_indent_based_list__multiline_indent(self):
+        LINE = '  cfg_line'
+        cfg = LINE + '\n' + LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        res = [(2, LINE), (2, LINE)]
+        self.assertEqual(res, parser._indent_list)
+
+    def test_init__multiline_blank(self):
+        LINE = ""
+        cfg = LINE + "\n" + LINE + "\n" + LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        self.assertEqual([], parser._indent_list)
+
+    def test_init__multiline_mixed(self):
+        LINE = " cfg_line"
+        cfg = LINE + "\n" + "  \n" + LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        res = [(1, ' cfg_line'), (1, ' cfg_line')]
+        self.assertEqual(res, parser._indent_list)
+
+    def test_init__multiline_mixed_different_indent(self):
+        LINE = "cfg_line"
+        cfg = "  " + LINE + "\n" + "  \n" + "   " + LINE
+        parser = HTParser(cfg)
+        parser.find_objects("fake_object")
+        res = [(2, '  cfg_line'), (3, '   cfg_line')]
+        self.assertEqual(res, parser._indent_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ Babel>=1.3
 ncclient>=0.4.2
 lxml>=3.3.3
 UcsSdk<=0.8.2
-ciscoconfparse>=1.2.10
 neutron>=2015.1.0,<2015.2.0

--- a/tools/packages/debian/control
+++ b/tools/packages/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/CiscoSystems/networking-cisco
 
 Package: networking-cisco
 Architecture: all
-Depends: ${misc:Depends}, python-ncclient, python-ciscoconfparse,
+Depends: ${misc:Depends}, python-ncclient,
          python-novaclient, python-ucssdk
 Description: Neutron layer 3 plugin for Cisco devices
  Provides Layer 3 support for Cisco routing products


### PR DESCRIPTION
This commit introduces a simple hierarchical text parser called
HTParser. It uses indent levels to determine parent child hierarchy,
specifically in IOS config strings. In this application we use the
parser to determine the presence of a specific config or sub-configs
in a config resource.

This in-tree module replaces the use of the ciscoconfparse library.
Only a subset of functionality provided by ciscoconfparse is used
currently and having a module in-tree for the same gives us more
flexibility.

This closes #168

Signed-off-by: Thomas Bachman tbachman@yahoo.com
