### PR TITLE
Fix namespace collision with superclass.

### DIFF
--- a/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
+++ b/networking_cisco/plugins/cisco/db/l3/l3_router_appliance_db.py
@@ -543,7 +543,7 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
             return self._create_floatingip_gbp(context,
                 floatingip, initial_status=FLOATINGIP_STATUS_ACTIVE)
         else:
-            return self._create_floatingip(context,
+            return self._create_floatingip_neutron(context,
                 floatingip, initial_status=FLOATINGIP_STATUS_ACTIVE)
 
     def _create_floatingip_gbp(self, context, floatingip,
@@ -592,8 +592,8 @@ class L3RouterApplianceDBMixin(extraroute_db.ExtraRoute_dbonly_mixin):
         self._notify_affected_routers(context, router_ids, 'create_floatingip')
         return result
 
-    def _create_floatingip(self, context, floatingip,
-                           initial_status=FLOATINGIP_STATUS_ACTIVE):
+    def _create_floatingip_neutron(self, context, floatingip,
+                                   initial_status=FLOATINGIP_STATUS_ACTIVE):
         info = super(L3RouterApplianceDBMixin, self).create_floatingip(
             context, floatingip, initial_status)
         router_ids = [info['router_id']] if info['router_id'] else []

--- a/networking_cisco/tests/unit/cisco/l3/test_l3_router_appliance_plugin.py
+++ b/networking_cisco/tests/unit/cisco/l3/test_l3_router_appliance_plugin.py
@@ -503,7 +503,7 @@ class L3RouterApplianceNoGbpTestCase(test_l3.L3NatTestCaseMixin,
 
     def test_create_floatingip_gbp(self):
         self.plugin._update_fip_assoc = mock.Mock()
-        self.plugin._create_floatingip = mock.Mock()
+        self.plugin._create_floatingip_neutron = mock.Mock()
         self.plugin._create_floatingip_gbp = mock.Mock()
         ctx = q_context.get_admin_context()
         floating_ip = {
@@ -511,7 +511,7 @@ class L3RouterApplianceNoGbpTestCase(test_l3.L3NatTestCaseMixin,
         }
         self.plugin.create_floatingip(ctx, floating_ip)
         self.plugin._create_floatingip_gbp.assert_not_called()
-        self.plugin._create_floatingip.assert_called_once_with(ctx,
+        self.plugin._create_floatingip_neutron.assert_called_once_with(ctx,
             floating_ip, initial_status=l3_constants.FLOATINGIP_STATUS_ACTIVE)
 
     def test_update_floatingip_no_gbp(self):


### PR DESCRIPTION
This fixes a namespace collision in a superclass,
which was found with a MOS7.x deployment (MOS7.x
backports some patches from liberty, which is why
the namespace collision exists -- it isn't present
in vanilla stable/kilo).

This closes #170

Signed-off-by: Thomas Bachman tbachman@yahoo.com
