### PR TITLE
Add config syncer for ASR with ACI

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_cfg_syncer.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_cfg_syncer.py
@@ -1,0 +1,47 @@
+# Copyright 2016 Cisco Systems, Inc.  All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k import (
+    asr1k_cfg_syncer as syncer)
+
+
+LOG = logging.getLogger(__name__)
+
+
+IP_REGEX = "(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
+
+SET_ROUTE_REGEX = ("ip route vrf " +
+    syncer.NROUTER_REGEX + " " + IP_REGEX + " " + IP_REGEX +
+    " \S+\.(\d+) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})")
+SET_ROUTE_MULTI_REGION_REGEX = ("ip route vrf " +
+    syncer.NROUTER_MULTI_REGION_REGEX + " " +
+    IP_REGEX + " " + IP_REGEX +
+    " \S+\.(\d+) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})")
+
+
+class ConfigSyncer(syncer.ConfigSyncer):
+
+    def __init__(self, router_db_info, driver,
+                 hosting_device_info, test_mode=False):
+        super(ConfigSyncer, self).__init__(router_db_info,
+                                           driver,
+                                           hosting_device_info,
+                                           test_mode=test_mode)
+        if (cfg.CONF.multi_region.enable_multi_region):
+            self.route_regex = SET_ROUTE_MULTI_REGION_REGEX
+        else:
+            self.route_regex = SET_ROUTE_REGEX

--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_cfg_syncer.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_cfg_syncer.py
@@ -188,6 +188,10 @@ class ConfigSyncer(object):
         self.intf_segment_dict = interface_segment_dict
         self.segment_nat_dict = segment_nat_dict
         self.test_mode = test_mode
+        if (cfg.CONF.multi_region.enable_multi_region):
+            self.route_regex = DEFAULT_ROUTE_MULTI_REGION_REGEX
+        else:
+            self.route_regex = DEFAULT_ROUTE_REGEX
 
     def process_routers_data(self, routers):
         hd_id = self.hosting_device_info['id']
@@ -297,17 +301,13 @@ class ConfigSyncer(object):
                                            segment_nat_dict,
                                            parsed_cfg)
 
-        if (cfg.CONF.multi_region.enable_multi_region):
-            default_route_regex = DEFAULT_ROUTE_MULTI_REGION_REGEX
-        else:
-            default_route_regex = DEFAULT_ROUTE_REGEX
+        invalid_cfg += self.clean_routes(conn,
+                                         router_id_dict,
+                                         intf_segment_dict,
+                                         segment_nat_dict,
+                                         parsed_cfg,
+                                         self.route_regex)
 
-        invalid_cfg += self.clean_default_route(conn,
-                                                router_id_dict,
-                                                intf_segment_dict,
-                                                segment_nat_dict,
-                                                parsed_cfg,
-                                                default_route_regex)
         invalid_cfg += self.clean_acls(conn,
                                        intf_segment_dict,
                                        segment_nat_dict,
@@ -495,16 +495,16 @@ class ConfigSyncer(object):
         LOG.debug("delete_pool_list = %s " % (pp.pformat(delete_pool_list)))
         return delete_pool_list
 
-    def clean_default_route(self,
-                            conn,
-                            router_id_dict,
-                            intf_segment_dict,
-                            segment_nat_dict,
-                            parsed_cfg,
-                            route_regex):
+    def clean_routes(self,
+                     conn,
+                     router_id_dict,
+                     intf_segment_dict,
+                     segment_nat_dict,
+                     parsed_cfg,
+                     route_regex):
         delete_route_list = []
-        default_routes = parsed_cfg.find_objects(route_regex)
-        for route in default_routes:
+        routes = parsed_cfg.find_objects(route_regex)
+        for route in routes:
             LOG.info(_LI("\ndefault route: %s"), (route))
             match_obj = re.match(route_regex, route.text)
             is_multi_region_enabled = cfg.CONF.multi_region.enable_multi_region

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_aci_asr1k_cfg_syncer.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_aci_asr1k_cfg_syncer.py
@@ -1,0 +1,162 @@
+# Copyright 2014 Cisco Systems, Inc.  All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+from oslo_serialization import jsonutils
+
+import mock
+from networking_cisco.tests import base
+from networking_cisco.tests.unit.cisco.cfg_agent import (
+    test_asr1k_cfg_syncer as test_sync)
+
+
+from networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k import (
+    aci_asr1k_cfg_syncer)
+from networking_cisco.plugins.cisco.common.htparser import LineItem
+
+INVALID_CFG_LIST_1 = [('ip nat inside source static 10.2.0.5 172.16.0.126 '
+                       'vrf nrouter-3ea5f9 redundancy '
+                       'neutron-hsrp-1064-3000'),
+                      ('ip nat inside source list neutron_acl_2564_47f1a63e '
+                       'pool nrouter-3ea5f9_nat_pool vrf nrouter-3ea5f9 '
+                       'overload'),
+                      ('ip nat pool nrouter-3ea5f9_nat_pool 172.16.0.124 '
+                       '172.16.0.124 netmask 255.255.0.0'),
+                      ('ip route vrf nrouter-3ea5f9 0.0.0.0 0.0.0.0 '
+                       'Port-channel10.3000 172.16.0.1'),
+                      'ip access-list standard neutron_acl_2564_47f1a63e',
+                      'interface Port-channel10.2564',
+                      'interface Port-channel10.3000',
+                      'nrouter-3ea5f9']
+
+INVALID_CFG_LIST_2 = [('ip nat inside source static 192.168.0.9 172.16.0.109 '
+                       'vrf nrouter-92740e-0000002 redundancy '
+                       'neutron-hsrp-1064-3000'),
+                      ('ip nat inside source static 20.20.20.5 172.16.0.118 '
+                       'vrf nrouter-bdc5b5-0000002 redundancy '
+                       'neutron-hsrp-1064-3000'),
+                      ('ip nat inside source static 20.20.20.7 172.16.0.120 '
+                       'vrf nrouter-bdc5b5-0000002 redundancy '
+                       'neutron-hsrp-1064-3000'),
+                      ('ip nat inside source static 10.2.0.5 172.16.0.126 vrf '
+                       'nrouter-3ea5f9-0000002 redundancy '
+                       'neutron-hsrp-1064-3000'),
+                      ('ip nat inside source list '
+                       'neutron_acl_0000002_2564_47f1a63e pool '
+                       'nrouter-3ea5f9-0000002_nat_pool vrf '
+                       'nrouter-3ea5f9-0000002 overload'),
+                      ('ip nat inside source list '
+                       'neutron_acl_0000002_2535_86f655d1 pool '
+                       'nrouter-92740e-0000002_nat_pool vrf '
+                       'nrouter-92740e-0000002 overload'),
+                      ('ip nat inside source list '
+                       'neutron_acl_0000002_2577_3f70129a pool'
+                       ' nrouter-bdc5b5-0000002_nat_pool vrf '
+                       'nrouter-bdc5b5-0000002 overload'),
+                      ('ip nat pool nrouter-92740e-0000002_nat_pool '
+                       '172.16.0.101 172.16.0.101 netmask 255.255.0.0'),
+                      ('ip nat pool nrouter-bdc5b5-0000002_nat_pool '
+                       '172.16.0.116 172.16.0.116 netmask 255.255.0.0'),
+                      ('ip nat pool nrouter-3ea5f9-0000002_nat_pool '
+                       '172.16.0.124 172.16.0.124 netmask 255.255.0.0'),
+                      ('ip route vrf nrouter-92740e-0000002 0.0.0.0 0.0.0.0 '
+                       'Port-channel10.3000 172.16.0.1'),
+                      ('ip route vrf nrouter-bdc5b5-0000002 0.0.0.0 0.0.0.0 '
+                       'Port-channel10.3000 172.16.0.1'),
+                      ('ip route vrf nrouter-3ea5f9-0000002 0.0.0.0 0.0.0.0 '
+                       'Port-channel10.3000 172.16.0.1'),
+                      ('ip access-list standard '
+                       'neutron_acl_0000002_2535_86f655d1'),
+                      ('ip access-list standard '
+                       'neutron_acl_0000002_2564_47f1a63e'),
+                      ('ip access-list standard '
+                       'neutron_acl_0000002_2577_3f70129a'),
+                      'interface Port-channel10.2535',
+                      'interface Port-channel10.2564',
+                      'interface Port-channel10.2577',
+                      'interface Port-channel10.3000',
+                      'nrouter-92740e-0000002',
+                      'nrouter-3ea5f9-0000002',
+                      'nrouter-bdc5b5-0000002']
+
+
+class AciASR1kCfgSyncer(test_sync.ASR1kCfgSyncer):
+
+    def _read_neutron_db_data(self):
+        """
+        helper function for reading the dummy neutron router db
+        """
+        with open(base.ROOTDIR +
+                  '/unit/cisco/etc/cfg_syncer/neutron_router_db.json',
+                  'r') as fp:
+            self.router_db_info = jsonutils.load(fp)
+
+    def setUp(self):
+        super(AciASR1kCfgSyncer, self).setUp()
+
+        self.config_syncer = aci_asr1k_cfg_syncer.ConfigSyncer(
+            self.router_db_info, self.driver, self.hosting_device_info)
+
+    def tearDown(self):
+        super(AciASR1kCfgSyncer, self).tearDown()
+
+    def test_delete_invalid_cfg_empty_routers_list(self):
+        cfg.CONF.set_override('enable_multi_region', False, 'multi_region')
+
+        router_db_info = []
+
+        self.config_syncer = aci_asr1k_cfg_syncer.ConfigSyncer(router_db_info,
+                                                      self.driver,
+                                                      self.hosting_device_info)
+        self.config_syncer.get_running_config = mock.Mock(
+            return_value=self._read_asr_running_cfg(
+                               'asr_basic_running_cfg_no_multi_region.json'))
+
+        invalid_cfg = self.config_syncer.delete_invalid_cfg()
+        self.assertEqual(8, len(invalid_cfg))
+        for i in range(len(INVALID_CFG_LIST_1)):
+            if isinstance(invalid_cfg[i], LineItem):
+                check_string = invalid_cfg[i].line
+            else:
+                check_string = invalid_cfg[i]
+            self.assertEqual(check_string,
+                             INVALID_CFG_LIST_1[i]),
+
+    def test_delete_invalid_cfg_with_multi_region_and_empty_routers_list(self):
+        """
+        This test verifies that the  cfg-syncer will delete invalid cfg
+        if the neutron-db (routers dictionary list) happens to be empty.
+
+        Since the neutron-db router_db_info is empty, all region 0000002
+        running-config should be deleted.
+        """
+        cfg.CONF.set_override('enable_multi_region', True, 'multi_region')
+        cfg.CONF.set_override('region_id', '0000002', 'multi_region')
+        cfg.CONF.set_override('other_region_ids', ['0000001'], 'multi_region')
+        router_db_info = []
+        self.config_syncer = aci_asr1k_cfg_syncer.ConfigSyncer(router_db_info,
+                                                      self.driver,
+                                                      self.hosting_device_info)
+        self.config_syncer.get_running_config = \
+            mock.Mock(return_value=self._read_asr_running_cfg(
+                                            'asr_running_cfg.json'))
+        invalid_cfg = self.config_syncer.delete_invalid_cfg()
+        self.assertEqual(23, len(invalid_cfg))
+        for i in range(len(INVALID_CFG_LIST_2)):
+            if isinstance(invalid_cfg[i], LineItem):
+                check_string = invalid_cfg[i].line
+            else:
+                check_string = invalid_cfg[i]
+            self.assertEqual(check_string,
+                             INVALID_CFG_LIST_2[i]),

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
@@ -27,6 +27,8 @@ from networking_cisco.plugins.cisco.cfg_agent.device_drivers.asr1k import (
     asr1k_snippets as asr_snippets)
 from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
     cisco_csr1kv_snippets as csr_snippets)
+from networking_cisco.plugins.cisco.cfg_agent.device_drivers.csr1kv import (
+    iosxe_routing_driver as iosxe_driver)
 from networking_cisco.plugins.cisco.cfg_agent.service_helpers import (
     routing_svc_helper)
 from networking_cisco.tests.unit.cisco.cfg_agent import (
@@ -60,7 +62,9 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
         self.ri_global.router['tenant_id'] = _uuid()
         self.router['tenant_id'] = _uuid()
         self.ri = routing_svc_helper.RouterInfo(FAKE_ID, self.router)
-        self.vrf = self.ri.router['tenant_id']
+        self.vrf = ('nrouter-' +
+                    self.ri.router['tenant_id'])[
+                        :iosxe_driver.IosXeRoutingDriver.DEV_NAME_LEN]
         self.driver._get_vrfs = mock.Mock(return_value=[self.vrf])
         self.transit_gw_ip = '1.103.2.254'
         self.transit_gw_vip = '1.103.2.2'
@@ -107,9 +111,11 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
         self.ri.internal_ports = int_ports
         self.ri_global.internal_ports = int_ports
         self.TEST_CIDR = '20.0.0.0/24'
+        self.TEST_SNAT_IP = '20.0.0.2'
         self.TEST_SNAT_ID = _uuid()
         self.ex_gw_port['hosting_info']['snat_subnets'] = [
             {'id': self.TEST_SNAT_ID,
+             'ip': self.TEST_SNAT_IP,
              'cidr': self.TEST_CIDR}
         ]
         net = netaddr.IPNetwork(self.TEST_CIDR)


### PR DESCRIPTION
This adds the config syncer needed when the ASR
is used/integrated with ACI.

This closes issue #147

Signed-off-by: Thomas Bachman tbachman@yahoo.com
