### PR TITLE
Fixes for VRF handling in ASR

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_snippets.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_snippets.py
@@ -178,3 +178,10 @@ SET_GLOBAL_CONFIG = """
 REMOVE_GLOBAL_CONFIG = """
             <cmd>no %s</cmd>
 """
+
+# =============================================================================
+# VRF definition -- used only for checking existence in the
+# running config (note absence of <config> and <cli-config-data> elements).
+# Syntax: completely defined by parameter
+# =============================================================================
+VRF_CONFIG = """vrf definition %s"""

--- a/networking_cisco/plugins/cisco/cfg_agent/service_helpers/routing_svc_helper.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/service_helpers/routing_svc_helper.py
@@ -610,6 +610,66 @@ class RoutingServiceHelper(object):
             self.plugin_rpc.send_update_port_statuses(self.context,
                                                       chunk_ports, status)
 
+    def _get_internal_port_changes(self, ri, internal_ports):
+        existing_port_ids = set([p['id'] for p in ri.internal_ports])
+        current_port_ids = set([p['id'] for p in internal_ports
+                                if p['admin_state_up']])
+        new_ports = [p for p in internal_ports
+                     if
+                     p['id'] in (current_port_ids - existing_port_ids)]
+        old_ports = [p for p in ri.internal_ports
+                     if p['id'] not in current_port_ids]
+
+        new_port_ids = [p['id'] for p in new_ports]
+        old_port_ids = [p['id'] for p in old_ports]
+        LOG.debug("++ new_port_ids = %s" % (pp.pformat(new_port_ids)))
+        LOG.debug("++ old_port_ids = %s" % (pp.pformat(old_port_ids)))
+
+        return new_ports, old_ports
+
+    def _enable_disable_ports(self, ri, ex_gw_port, internal_ports):
+        if not ri.router['admin_state_up']:
+            self._disable_router_interface(ri)
+        else:
+            if ex_gw_port:
+                if not ex_gw_port['admin_state_up']:
+                    self._disable_router_interface(ri, ex_gw_port)
+                else:
+                    self._enable_router_interface(ri, ex_gw_port)
+            for port in internal_ports:
+                if not port['admin_state_up']:
+                    self._disable_router_interface(ri, port)
+                else:
+                    self._enable_router_interface(ri, port)
+
+    def _process_new_ports(self, ri, new_ports, ex_gw_port, list_port_ids_up):
+        for p in new_ports:
+            self._set_subnet_info(p)
+            self._internal_network_added(ri, p, ex_gw_port)
+            ri.internal_ports.append(p)
+            list_port_ids_up.append(p['id'])
+
+    def _process_old_ports(self, ri, old_ports, ex_gw_port):
+        for p in old_ports:
+            self._internal_network_removed(ri, p, ri.ex_gw_port)
+            ri.internal_ports.remove(p)
+
+    def _process_gateway_set(self, ri, ex_gw_port, list_port_ids_up):
+        self._set_subnet_info(ex_gw_port)
+        self._external_gateway_added(ri, ex_gw_port)
+        list_port_ids_up.append(ex_gw_port['id'])
+
+    def _process_gateway_cleared(self, ri, ex_gw_port):
+        self._external_gateway_removed(ri, ex_gw_port)
+
+    def _add_rid_to_vrf_list(self, ri):
+        # not needed in base service helper
+        pass
+
+    def _remove_rid_from_vrf_list(self, ri):
+        # not needed in base service helper
+        pass
+
     def _process_router(self, ri):
         """Process a router, apply latest configuration and update router_info.
 
@@ -628,39 +688,31 @@ class RoutingServiceHelper(object):
         """
         try:
             ex_gw_port = ri.router.get('gw_port')
+            gateway_set = ex_gw_port and not ri.ex_gw_port
+            gateway_cleared = not ex_gw_port and ri.ex_gw_port
             internal_ports = ri.router.get(l3_constants.INTERFACE_KEY, [])
+            # Once the gateway is set, then we know which VRF
+            # this router belongs to. Keep track of it in our
+            # lists of routers, organized as a dictionary by
+            # VRF name
+            if gateway_set:
+                self._add_rid_to_vrf_list(ri)
 
-            existing_port_ids = set([p['id'] for p in ri.internal_ports])
-            current_port_ids = set([p['id'] for p in internal_ports
-                                    if p['admin_state_up']])
-            new_ports = [p for p in internal_ports
-                         if
-                         p['id'] in (current_port_ids - existing_port_ids)]
-            old_ports = [p for p in ri.internal_ports
-                         if p['id'] not in current_port_ids]
+            new_ports, old_ports = self._get_internal_port_changes(
+                ri, internal_ports)
 
-            new_port_ids = [p['id'] for p in new_ports]
-            old_port_ids = [p['id'] for p in old_ports]
             list_port_ids_up = []
-            LOG.debug("++ new_port_ids = %s" % (pp.pformat(new_port_ids)))
-            LOG.debug("++ old_port_ids = %s" % (pp.pformat(old_port_ids)))
 
-            for p in new_ports:
-                self._set_subnet_info(p)
-                self._internal_network_added(ri, p, ex_gw_port)
-                ri.internal_ports.append(p)
-                list_port_ids_up.append(p['id'])
+            self._process_new_ports(ri, new_ports,
+                                    ex_gw_port, list_port_ids_up)
 
-            for p in old_ports:
-                self._internal_network_removed(ri, p, ri.ex_gw_port)
-                ri.internal_ports.remove(p)
+            self._process_old_ports(ri, old_ports, ex_gw_port)
 
-            if ex_gw_port and not ri.ex_gw_port:
-                self._set_subnet_info(ex_gw_port)
-                self._external_gateway_added(ri, ex_gw_port)
-                list_port_ids_up.append(ex_gw_port['id'])
-            elif not ex_gw_port and ri.ex_gw_port:
-                self._external_gateway_removed(ri, ri.ex_gw_port)
+            if gateway_set:
+                self._process_gateway_set(ri, ex_gw_port,
+                                          list_port_ids_up)
+            elif gateway_cleared:
+                self._process_gateway_cleared(ri, ri.ex_gw_port)
 
             self._send_update_port_statuses(list_port_ids_up,
                                             l3_constants.PORT_STATUS_ACTIVE)
@@ -670,19 +722,11 @@ class RoutingServiceHelper(object):
             if ri.router[ROUTER_ROLE_ATTR] not in \
                     [c_constants.ROUTER_ROLE_GLOBAL,
                      c_constants.ROUTER_ROLE_LOGICAL_GLOBAL]:
-                if not ri.router['admin_state_up']:
-                    self._disable_router_interface(ri)
-                else:
-                    if ex_gw_port:
-                        if not ex_gw_port['admin_state_up']:
-                            self._disable_router_interface(ri, ex_gw_port)
-                        else:
-                            self._enable_router_interface(ri, ex_gw_port)
-                    for port in internal_ports:
-                        if not port['admin_state_up']:
-                            self._disable_router_interface(ri, port)
-                        else:
-                            self._enable_router_interface(ri, port)
+                self._enable_disable_ports(ri, ex_gw_port, internal_ports)
+
+                if gateway_cleared:
+                    # Remove this router from the list of routers by VRF
+                    self._remove_rid_from_vrf_list(ri)
 
             ri.ex_gw_port = ex_gw_port
             self._routes_updated(ri)

--- a/networking_cisco/plugins/cisco/cfg_agent/service_helpers/routing_svc_helper_aci.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/service_helpers/routing_svc_helper_aci.py
@@ -1,0 +1,123 @@
+# Copyright 2014 Cisco Systems, Inc.  All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_log import log as logging
+
+from neutron.common import constants as l3_constants
+
+from networking_cisco.plugins.cisco.cfg_agent.service_helpers import (
+    routing_svc_helper as helper)
+from networking_cisco.plugins.cisco.extensions import routerrole
+
+ROUTER_ROLE_ATTR = routerrole.ROUTER_ROLE_ATTR
+LOG = logging.getLogger(__name__)
+
+
+class RoutingServiceHelperAci(helper.RoutingServiceHelper):
+
+    def __init__(self, host, conf, cfg_agent):
+        super(RoutingServiceHelperAci, self).__init__(
+            host, conf, cfg_agent)
+        self._router_ids_by_vrf = {}
+
+    def _process_new_ports(self, ri, new_ports, ex_gw_port, list_port_ids_up):
+        # Only add internal networks if we have an
+        # eternal gateway -- otherwise we have no parameters
+        # to use to configure the interface (e.g. VRF, IP, etc.)
+        if ex_gw_port:
+            super(RoutingServiceHelperAci,
+                  self)._process_new_ports(
+                      ri, new_ports, ex_gw_port, list_port_ids_up)
+
+    def _process_old_ports(self, ri, old_ports, ex_gw_port):
+        gw_port = ri.router.get('gw_port') or ri.ex_gw_port
+        for p in old_ports:
+            LOG.debug("++ removing port id = %s (gw = %s)" %
+                      (p['id'], gw_port))
+            # We can only clear the port if we stil have all
+            # the relevant information (VRF and external network
+            # parameters), which come from the GW port. Go ahead
+            # and remove the interface from our internal state
+            if gw_port:
+                self._internal_network_removed(ri, p, gw_port)
+            ri.internal_ports.remove(p)
+
+    def _process_gateway_set(self, ri, ex_gw_port, list_port_ids_up):
+        super(RoutingServiceHelperAci,
+              self)._process_gateway_set(ri, ex_gw_port, list_port_ids_up)
+        # transiiioned -- go enable any interfaces
+        interfaces = ri.router.get(l3_constants.INTERFACE_KEY, [])
+        new_ports = [p for p in interfaces
+                     if (p['admin_state_up'] and
+                         p not in ri.internal_ports)]
+        super(RoutingServiceHelperAci,
+              self)._process_new_ports(
+                  ri, new_ports, ex_gw_port, list_port_ids_up)
+
+    def _process_gateway_cleared(self, ri, ex_gw_port):
+        super(RoutingServiceHelperAci,
+              self)._process_gateway_cleared(ri, ex_gw_port)
+        # remove the internal networks at this time,
+        # while the gateway information is still available
+        # (has VRF network parameters)
+        old_ports = [p for p in ri.internal_ports
+                     if p['admin_state_up']]
+        super(RoutingServiceHelperAci,
+              self)._process_old_ports(ri, old_ports, ex_gw_port)
+
+    def _add_rid_to_vrf_list(self, ri):
+        """Add router ID to a VRF list.
+
+        In order to properly manage VRFs in the ASR, their
+        usage has to be tracked. VRFs are provided with neutron
+        router objects in their hosting_info fields of the gateway ports.
+        This means that the VRF is only available when the gateway port
+        of the router is set. VRFs can span routers, and even OpenStack
+        tenants, so lists of routers that belong to the same VRF are
+        kept in a dictionary, with the VRF name as the key.
+        """
+        if ri.ex_gw_port or ri.router.get('gw_port'):
+            driver = self.driver_manager.get_driver(ri.id)
+            vrf_name = driver._get_vrf_name(ri)
+            if not vrf_name:
+                return
+            if not self._router_ids_by_vrf.get(vrf_name):
+                LOG.debug("++ CREATING VRF %s" % vrf_name)
+                driver._do_create_vrf(vrf_name)
+            self._router_ids_by_vrf.setdefault(vrf_name, set()).add(
+                ri.router['id'])
+
+    def _remove_rid_from_vrf_list(self, ri):
+        """Remove router ID from a VRF list.
+
+        In order to properly manage VRFs in the ASR, their
+        usage has to be tracked. VRFs are provided with neutron
+        router objects in their hosting_info fields of the gateway ports.
+        This means that the VRF is only available when the gateway port
+        of the router is set. VRFs can span routers, and even OpenStack
+        tenants, so lists of routers that belong to the same VRF are
+        kept in a dictionary, with the VRF name as the key.
+        """
+        if ri.ex_gw_port or ri.router.get('gw_port'):
+            driver = self.driver_manager.get_driver(ri.id)
+            vrf_name = driver._get_vrf_name(ri)
+            if self._router_ids_by_vrf.get(vrf_name) and (
+                    ri.router['id'] in self._router_ids_by_vrf[vrf_name]):
+                self._router_ids_by_vrf[vrf_name].remove(ri.router['id'])
+                # If this is the last router in a VRF, then we can safely
+                # delete the VRF from the router config (handled by the driver)
+                if not self._router_ids_by_vrf.get(vrf_name):
+                    LOG.debug("++ REMOVING VRF %s" % vrf_name)
+                    driver._remove_vrf(ri)
+                    del self._router_ids_by_vrf[vrf_name]

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_routing_svc_helper_aci.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_routing_svc_helper_aci.py
@@ -1,0 +1,34 @@
+# Copyright 2014 Cisco Systems, Inc.  All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import mock
+from networking_cisco.plugins.cisco.cfg_agent.service_helpers import (
+    routing_svc_helper_aci as svc_helper)
+from networking_cisco.tests.unit.cisco.cfg_agent import (
+    test_routing_svc_helper as helper)
+
+
+class TestBasicRoutingOperationsAci(helper.TestBasicRoutingOperations):
+
+    def setUp(self):
+        super(TestBasicRoutingOperationsAci, self).setUp()
+        self.routing_helper = svc_helper.RoutingServiceHelperAci(
+            helper.HOST, self.conf, self.agent)
+        self.routing_helper._internal_network_added = mock.Mock()
+        self.routing_helper._external_gateway_added = mock.Mock()
+        self.routing_helper._internal_network_removed = mock.Mock()
+        self.routing_helper._external_gateway_removed = mock.Mock()
+        self.driver = self._mock_driver_and_hosting_device(
+            self.routing_helper)


### PR DESCRIPTION
The mapping of VRFs in the ASR was wrong, as it didn't support
the multiple mappings possible in the different GBP and APIC ML2
work flows. This patch adds proper mappings for and handling
for VRFs with ACI.

This closes issues #223, #221, #216, #212

Signed-off-by: Thomas Bachman tbachman@yahoo.com
