### PR TITLE
Configure secondary IPs using global router

### DIFF
--- a/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
+++ b/networking_cisco/plugins/cisco/device_manager/plugging_drivers/aci_vlan_trunking_driver.py
@@ -239,7 +239,7 @@ class AciVLANTrunkingPlugDriver(hw_vlan.HwVLANTrunkingPlugDriver):
         ext_net_name = network['name']
         if (APIC_SNAT_NET + '-') in ext_net_name:
             # This is APIC ML2 mode -- we need to strip the prefix
-            ext_net_name = ext_net_name.strip(APIC_SNAT_NET + '-')
+            ext_net_name = ext_net_name[len(APIC_SNAT_NET + '-'):]
             if net['id'] == ext_net_name:
                 return True
         return False


### PR DESCRIPTION
This patch configures secondary IPs on the ASR's external interface
whenever the global router's external gateway is set or cleared.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
