### PR TITLE
Fix SNAT pool name when associating with ACL

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_routing_driver.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/asr1k_routing_driver.py
@@ -509,7 +509,11 @@ class ASR1kRoutingDriver(iosxe_driver.IosXeRoutingDriver):
     def _is_port_v6(port):
         return netaddr.IPNetwork(port['subnets'][0]['cidr']).version == 6
 
+    def _get_snat_prefix(self, ri, ext_port):
+        return self._get_vrf_name(ri)
+
     def _add_internal_nw_nat_rules(self, ri, port, ext_port):
+        snat_prefix = self._get_snat_prefix(ri, ext_port)
         vrf_name = self._get_vrf_name(ri)
         acl_no = self._generate_acl_num_from_port(port)
         internal_cidr = port['ip_cidr']
@@ -519,7 +523,7 @@ class ASR1kRoutingDriver(iosxe_driver.IosXeRoutingDriver):
         outer_itfc = self._get_interface_name_from_hosting_port(ext_port)
         self._nat_rules_for_internet_access(acl_no, internal_net,
                                             net_mask, inner_itfc,
-                                            outer_itfc, vrf_name)
+                                            outer_itfc, vrf_name, snat_prefix)
 
     def _nat_rules_for_internet_access(self,
                                        acl_no,
@@ -527,7 +531,8 @@ class ASR1kRoutingDriver(iosxe_driver.IosXeRoutingDriver):
                                        netmask,
                                        inner_itfc,
                                        outer_itfc,
-                                       vrf_name):
+                                       vrf_name,
+                                       snat_prefix):
         """Configure the NAT rules for an internal network.
 
         Configuring NAT rules in the CSR1kv is a three step process. First
@@ -554,7 +559,7 @@ class ASR1kRoutingDriver(iosxe_driver.IosXeRoutingDriver):
             conf_str = snippets.CREATE_ACL % (acl_no, network, netmask)
             self._edit_running_config(conf_str, 'CREATE_ACL')
 
-        pool_name = "%s_nat_pool" % vrf_name
+        pool_name = "%s_nat_pool" % snat_prefix
         conf_str = asr1k_snippets.SET_DYN_SRC_TRL_POOL % (acl_no, pool_name,
                                                           vrf_name)
         try:
@@ -608,14 +613,17 @@ class ASR1kRoutingDriver(iosxe_driver.IosXeRoutingDriver):
         # self._remove_dyn_nat_translations()
 
         # remove dynamic nat rules and acls
+        snat_prefix = self._get_snat_prefix(ri, ext_port)
         vrf_name = self._get_vrf_name(ri)
         ext_itfc_name = self._get_interface_name_from_hosting_port(ext_port)
         for acl in acls:
-            self._remove_dyn_nat_rule(acl, ext_itfc_name, vrf_name)
+            self._remove_dyn_nat_rule(acl, ext_itfc_name,
+                                      vrf_name, snat_prefix)
 
-    def _remove_dyn_nat_rule(self, acl_no, outer_itfc_name, vrf_name):
+    def _remove_dyn_nat_rule(self, acl_no,
+                             outer_itfc_name, vrf_name, snat_prefix):
         try:
-            pool_name = "%s_nat_pool" % (vrf_name)
+            pool_name = "%s_nat_pool" % (snat_prefix)
             confstr = (asr1k_snippets.REMOVE_DYN_SRC_TRL_POOL %
                 (acl_no, pool_name, vrf_name))
             self._edit_running_config(confstr, 'REMOVE_DYN_SRC_TRL_POOL')

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
@@ -139,8 +139,9 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
         self.ex_gw_port['hosting_info']['global_config'] = [
             [self.GLOBAL_CFG_STRING_1, self.GLOBAL_CFG_STRING_2]]
         net = netaddr.IPNetwork(self.TEST_CIDR)
-        self.TEST_SNAT_POOL_ID = (driver.NAT_POOL_PREFIX +
-            self.TEST_SNAT_ID[:self.driver.NAT_POOL_ID_LEN] + '_nat_pool')
+        self.snat_prefix = (driver.NAT_POOL_PREFIX +
+            self.TEST_SNAT_ID[:self.driver.NAT_POOL_ID_LEN])
+        self.TEST_SNAT_POOL_ID = self.snat_prefix + '_nat_pool'
         self.TEST_CIDR_SNAT_IP = str(netaddr.IPAddress(net.first + 2))
         self.TEST_CIDR_SECONDARY_IP = str(netaddr.IPAddress(net.last - 1))
 

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_asr1k_routing_driver.py
@@ -66,6 +66,7 @@ class ASR1kRoutingDriver(base.BaseTestCase):
 
         self.vrf = ('nrouter-' + FAKE_ID)[:iosxe_driver.IosXeRoutingDriver.
                                           DEV_NAME_LEN]
+        self.snat_prefix = self.vrf
         self.driver._get_vrfs = mock.Mock(return_value=[self.vrf])
         self.ex_gw_ip = '20.0.0.31'
         # VIP is same as gw_ip for user visible router
@@ -490,7 +491,7 @@ class ASR1kRoutingDriver(base.BaseTestCase):
         self.assert_edit_run_cfg(
             csr_snippets.CREATE_ACL, cfg_params_create_acl)
 
-        pool_name = "%s_nat_pool" % self.vrf
+        pool_name = "%s_nat_pool" % self.snat_prefix
         cfg_params_dyn_trans = (acl_name, pool_name, self.vrf)
         self.assert_edit_run_cfg(
             snippets.SET_DYN_SRC_TRL_POOL, cfg_params_dyn_trans)
@@ -525,7 +526,8 @@ class ASR1kRoutingDriver(base.BaseTestCase):
         self.assert_edit_run_cfg(
             csr_snippets.CREATE_ACL, cfg_params_create_acl)
 
-        pool_name = "%s_nat_pool" % vrf
+        snat_prefix = self.snat_prefix + "-" + region_id
+        pool_name = "%s_nat_pool" % snat_prefix
         cfg_params_dyn_trans = (acl_name, pool_name, vrf)
         self.assert_edit_run_cfg(
             snippets.SET_DYN_SRC_TRL_POOL, cfg_params_dyn_trans)
@@ -547,7 +549,7 @@ class ASR1kRoutingDriver(base.BaseTestCase):
 
         acl_name = '%s_%s_%s' % ('neutron_acl',
                                  str(self.vlan_int), self.port['id'][:8])
-        pool_name = "%s_nat_pool" % self.vrf
+        pool_name = "%s_nat_pool" % self.snat_prefix
 
         cfg_params_dyn_trans = (acl_name, pool_name, self.vrf)
         self.assert_edit_run_cfg(
@@ -572,7 +574,8 @@ class ASR1kRoutingDriver(base.BaseTestCase):
                         region_id,
                         str(self.vlan_int),
                         self.port['id'][:8])
-        pool_name = "%s_nat_pool" % vrf
+        snat_prefix = self.snat_prefix + "-" + region_id
+        pool_name = "%s_nat_pool" % snat_prefix
 
         cfg_params_dyn_trans = (acl_name, pool_name, vrf)
         self.assert_edit_run_cfg(


### PR DESCRIPTION
The naming convention used to associate ACLs with
SNAT pools was wrong. This patch fixes that.

This closes issue #255

Signed-off-by: Thomas Bachman tbachman@yahoo.com
