### PR TITLE
Fix multi-VRF OSPF support

### DIFF
--- a/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
+++ b/networking_cisco/plugins/cisco/cfg_agent/device_drivers/asr1k/aci_asr1k_routing_driver.py
@@ -59,7 +59,8 @@ class AciASR1kRoutingDriver(asr1k.ASR1kRoutingDriver):
         self.hosting_device = {'id': device_params.get('id'),
                                'device_id': device_params.get('device_id')}
         self._template_dict = {'vrf': self._set_vrf,
-                               'vrf_pid': self._set_vrf_pid}
+                               'vrf_pid': self._set_vrf_pid,
+                               'rid': self._set_router_id}
         self._router_ids_by_snat_id = {}
         self._subnets_by_ext_net = {}
         # We need to limit the prefix to the overall DEV_NAME_LEN
@@ -558,13 +559,19 @@ class AciASR1kRoutingDriver(asr1k.ASR1kRoutingDriver):
         return self._get_vrf_name(ri)
 
     def _set_vrf_pid(self, ri, port, config):
-        # Convert a VRF to a process iD for a router instance
+        # Convert a VRF to a process ID for a router instance
         vrf = self._get_vrf_name(ri).strip('nrouter-')[:6]
         # strip to 4 characters to limit pid to 16-bit value
         # (limit on ASR)
         # TODO(tbachman): fix to ensure PID uniqueness
         pid = int(hashlib.md5(vrf).hexdigest()[:4], 16)
         return str(pid)
+
+    def _set_router_id(self, ri, port, config):
+        # Convert a VRF to a router ID for a router instance
+        vrf = self._get_vrf_name(ri).strip('nrouter-')[:6]
+        rid = netaddr.IPAddress(int(vrf, 16))
+        return str(rid)
 
     def _get_snat_pool_name(self, subnet):
         snat_prefix = self._snat_prefix(subnet)

--- a/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
+++ b/networking_cisco/tests/unit/cisco/cfg_agent/test_aciasr1k_routing_driver.py
@@ -76,6 +76,7 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
         self.transit_vlan = '1035'
         self.GLOBAL_CFG_STRING_1 = 'router ospf {vrf_pid} vrf {vrf}'
         self.GLOBAL_CFG_STRING_2 = 'area 0.0.0.1 nssa'
+        self.GLOBAL_CFG_STRING_3 = 'router-id {rid}'
         self.int_port_w_config = (
             {'id': PORT_ID,
              'ip_cidr': self.gw_ip_cidr,
@@ -137,7 +138,9 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
         self.ex_gw_port['cidr_exposed'] = self.transit_cidr
         self.ex_gw_port['extra_subnets'] = []
         self.ex_gw_port['hosting_info']['global_config'] = [
-            [self.GLOBAL_CFG_STRING_1, self.GLOBAL_CFG_STRING_2]]
+            [self.GLOBAL_CFG_STRING_1,
+             self.GLOBAL_CFG_STRING_2,
+             self.GLOBAL_CFG_STRING_3]]
         net = netaddr.IPNetwork(self.TEST_CIDR)
         self.snat_prefix = (driver.NAT_POOL_PREFIX +
             self.TEST_SNAT_ID[:self.driver.NAT_POOL_ID_LEN])
@@ -265,6 +268,10 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
             self.GLOBAL_CFG_STRING_1.format(
                 vrf=self.vrf, vrf_pid=self.vrf_pid))
         cfg_global += snippets.SET_GLOBAL_CONFIG % (self.GLOBAL_CFG_STRING_2)
+        rid = netaddr.IPAddress(int(self.vrf.strip('nrouter-')[:6], 16))
+        cfg_global += snippets.SET_GLOBAL_CONFIG % (
+            self.GLOBAL_CFG_STRING_3.format(
+                rid=str(rid)))
         cfg_global += snippets.GLOBAL_CONFIG_POSTFIX
         self.assert_edit_run_cfg(cfg_global, None)
 
@@ -280,6 +287,10 @@ class ASR1kRoutingDriverAci(asr1ktest.ASR1kRoutingDriver):
                 vrf=self.vrf, vrf_pid=self.vrf_pid))
         cfg_global += snippets.REMOVE_GLOBAL_CONFIG % (
             self.GLOBAL_CFG_STRING_2)
+        rid = netaddr.IPAddress(int(self.vrf.strip('nrouter-')[:6], 16))
+        cfg_global += snippets.REMOVE_GLOBAL_CONFIG % (
+            self.GLOBAL_CFG_STRING_3.format(
+                rid=str(rid)))
         cfg_global += snippets.GLOBAL_CONFIG_POSTFIX
         self.assert_edit_run_cfg(cfg_global, None)
         self.port = self.int_port


### PR DESCRIPTION
This patch adds a new template variable to set the router ID
for OSPF instances, scoped by VRF.

This closes issue #258

Signed-off-by: Thomas Bachman tbachman@yahoo.com
